### PR TITLE
Only show new guest note button i if anonymous editing is enabled

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -51,7 +51,9 @@ function responseError (res, code, detail, msg) {
     code: code,
     detail: detail,
     msg: msg,
-    useCDN: config.usecdn
+    useCDN: config.usecdn,
+    allowAnonymousEdits: false,
+    signin: false
   })
 }
 
@@ -80,7 +82,7 @@ function showIndex (req, res, next) {
   })
 }
 
-function responseHackMD (res, note) {
+function responseHackMD (req, res, note) {
   var body = note.content
   var extracted = models.Note.extractMeta(body)
   var meta = models.Note.parseMeta(extracted.meta)
@@ -108,6 +110,7 @@ function responseHackMD (res, note) {
     saml: config.isSAMLEnable,
     email: config.isEmailEnable,
     allowemailregister: config.allowemailregister,
+    signin: req.isAuthenticated(),
     allowpdfexport: config.allowpdfexport
   })
 }
@@ -116,7 +119,7 @@ function newNote (req, res, next) {
   var owner = null
   if (req.isAuthenticated()) {
     owner = req.user.id
-  } else if (!config.allowanonymous) {
+  } else if (!config.allowanonymousedits) {
     return response.errorForbidden(res)
   }
   models.Note.create({
@@ -181,7 +184,7 @@ function showNote (req, res, next) {
     var noteId = req.params.noteId
     var id = LZString.compressToBase64(note.id)
     if ((note.alias && noteId !== note.alias) || (!note.alias && noteId !== id)) { return res.redirect(config.serverurl + '/' + (note.alias || id)) }
-    return responseHackMD(res, note)
+    return responseHackMD(req, res, note)
   })
 }
 
@@ -215,6 +218,8 @@ function showPublishNote (req, res, next) {
       var data = {
         title: title,
         description: meta.description || (markdown ? models.Note.generateDescription(markdown) : null),
+        allowAnonymousEdits: config.allowanonymousedits,
+        signin: req.isAuthenticated(),
         viewcount: note.viewcount,
         createtime: createtime,
         updatetime: updatetime,

--- a/public/views/hackmd/header.ejs
+++ b/public/views/hackmd/header.ejs
@@ -22,10 +22,12 @@
                 <i class="fa fa-caret-down"></i>
             </a>
             <ul class="dropdown-menu list" role="menu" aria-labelledby="menu">
+                <% if(allowAnonymousEdits || signin) { %>
                 <li role="presentation"><a role="menuitem" class="ui-new" tabindex="-1" href="<%- url %>/new" target="_blank"><i class="fa fa-plus fa-fw"></i> <%= __('New') %></a>
                 </li>
                 <li role="presentation"><a role="menuitem" class="ui-publish" tabindex="-1" href="#" target="_blank"><i class="fa fa-share-square-o fa-fw"></i> <%= __('Publish') %></a>
                 </li>
+                <% } %>
                 <li class="divider"></li>
                 <li class="dropdown-header"><%= __('Extra') %></li>
                 <li role="presentation"><a role="menuitem" class="ui-extra-revision" tabindex="-1" data-toggle="modal" data-target="#revisionModal"><i class="fa fa-history fa-fw"></i> <%= __('Revision') %></a>
@@ -118,6 +120,7 @@
             </li>
         </ul>
         <ul class="nav navbar-nav navbar-right" style="padding:0;">
+            <% if(allowAnonymousEdits || signin) { %>
             <li>
                 <a href="<%- url %>/new" target="_blank" class="ui-new">
                     <i class="fa fa-plus"></i> <%= __('New') %>
@@ -128,6 +131,7 @@
                     <i class="fa fa-share-square-o"></i> <%= __('Publish') %>
                 </a>
             </li>
+            <% } %>
             <li>
                 <a data-toggle="dropdown">
                     <%= __('Menu') %> <i class="fa fa-caret-down"></i>

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -12,7 +12,7 @@
                             <li class="ui-history<% if(signin) { %> active<% } %>"><a href="#"><%= __('History') %></a>
                             </li>
                             <div class="ui-signin" style="float: right; margin-top: 8px;<% if(signin) { %> display: none;<% } %>">
-                                <% if(allowAnonymous) { %>
+                                <% if(allowAnonymousEdits) { %>
                                 <a type="button" href="<%- url %>/new" class="btn btn-sm btn-primary"><i class="fa fa-plus"></i> <%= __('New guest note') %></a>
                                 <% } %>
                                 <% if(facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap || saml || email) { %>


### PR DESCRIPTION
Since there are two different settings: allowAnonymous and
allowAnonymousEdits, only show new guest note button in the latter case.

Same for publishing a note: if allowAnonymousEdits is not enabled, it makes no
sense to allow publishing a revision.

Signed-off-by: Alexander Bokovoy <ab@vda.li>