### PR TITLE
Add extended build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,22 @@ env:
 
 jobs:
   include:
+    - env: task=npm-build
+      node_js:
+        - 6
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
+        - export PATH="$HOME/.yarn/bin:$PATH"
+        - yarn
+        - npm run build
+    - env: task=npm-build
+      node_js:
+        - 8
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
+        - export PATH="$HOME/.yarn/bin:$PATH"
+        - yarn
+        - npm run build
     - env: task=npm-test
       node_js:
         - 6


### PR DESCRIPTION
As we currently don't build hackmd on CI testing, there are may errors
coming up we don't find. It's easy to mitigate this by running them.

This causes longer build times but way better results.