### PR TITLE
Add Print icon to slide view

### DIFF
--- a/public/docs/slide-example.md
+++ b/public/docs/slide-example.md
@@ -266,4 +266,12 @@ Press `B` or `.` on your keyboard to pause the presentation. This is helpful whe
 
 ---
 
+## Print your Slides
+
+Down below you can find a print icon<i class="fa fa-fw fa-print"></i>.
+
+After you click on it, use the print function of your browser (either CTRL+P or cmd+P) to print the slides as PDF.
+
+---
+
 # The End

--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -14,6 +14,7 @@ window.lastchangetime = window.lastchangeui.time.attr('data-updatetime')
 updateLastChange()
 const url = window.location.pathname
 $('.ui-edit').attr('href', `${url}/edit`)
+$('.ui-print').attr('href', `${url}?print-pdf`)
 
 $(document).ready(() => {
     // tooltip

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -69,7 +69,7 @@
                             &nbsp;<span class="text-uppercase ui-status-lastchange"></span>
                             <span class="ui-lastchange text-uppercase" data-createtime="<%- createtime %>" data-updatetime="<%- updatetime %>"></span>
                         </span>
-                        <span class="pull-right"><%- viewcount %> views <a href="#" class="ui-edit" title="Edit this note"><i class="fa fa-fw fa-pencil"></i></a></span>
+                        <span class="pull-right"><%- viewcount %> views <a href="#" class="ui-edit" title="Edit this note"><i class="fa fa-fw fa-pencil"></i></a><a class="ui-print" href="" title="Open print view"><i class="fa fa-fw fa-print"></i></a></span>
                         <br>
                         <% if(ownerprofile && owner !== lastchangeuser) { %>
                         <span class="ui-owner">


### PR DESCRIPTION
It redirects the user to the print view of the document. I claim that
people should either be smart enough to use ctrl+P or ask someone who
knows how to print a webpage. I don't want to babysit our users.

Fixes #33 