### PR TITLE
Fix broken unicode urls

### DIFF
--- a/public/js/lib/config/index.js
+++ b/public/js/lib/config/index.js
@@ -7,7 +7,7 @@ export const debug = window.debug || false
 export const port = window.location.port
 export const serverurl = `${window.location.protocol}//${domain || window.location.hostname}${port ? ':' + port : ''}${urlpath ? '/' + urlpath : ''}`
 window.serverurl = serverurl
-export const noteid = urlpath ? window.location.pathname.slice(urlpath.length + 1, window.location.pathname.length).split('/')[1] : window.location.pathname.split('/')[1]
+export const noteid = decodeURIComponent(urlpath ? window.location.pathname.slice(urlpath.length + 1, window.location.pathname.length).split('/')[1] : window.location.pathname.split('/')[1])
 export const noteurl = `${serverurl}/${noteid}`
 
 export const version = window.version


### PR DESCRIPTION
It wasn't possible to create unicode based URLs in freeurl mode, because
the noteid used for the websocket connection is double escaped. When we
decode it and let socketio-client reencode it, we get the real
shortid/noteid and can find the note in the database and open the
connection.

![image](https://user-images.githubusercontent.com/8719867/41937466-a7f87686-7990-11e8-95de-ab8d579d8de2.png)

Fixes #729