### PR TITLE
Repository is not renamed to docker-codimd yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The easiest way to setup CodiMD using docker are using the following three comma
 
 ```console
 git clone https://github.com/hackmdio/docker-hackmd.git
-cd docker-codimd
+cd docker-hackmd
 docker-compose up
 ```
 Read more about it in the [docker repository…](https://github.com/hackmdio/docker-hackmd)


### PR DESCRIPTION
The repository is still named docker-hackmd instead docker-codimd.