### PR TITLE
Fixing content types in status router

### DIFF
--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -17,7 +17,8 @@ statusRouter.get('/status', function (req, res, next) {
   realtime.getStatus(function (data) {
     res.set({
       'Cache-Control': 'private', // only cache by client
-      'X-Robots-Tag': 'noindex, nofollow' // prevent crawling
+      'X-Robots-Tag': 'noindex, nofollow', // prevent crawling
+      'Content-Type': 'application/json'
     })
     res.send(data)
   })
@@ -101,7 +102,8 @@ statusRouter.get('/config', function (req, res) {
   }
   res.set({
     'Cache-Control': 'private', // only cache by client
-    'X-Robots-Tag': 'noindex, nofollow' // prevent crawling
+    'X-Robots-Tag': 'noindex, nofollow', // prevent crawling
+    'Content-Type': 'application/javascript'
   })
   res.render(config.constantsPath, data)
 })


### PR DESCRIPTION
As it turns out, expressjs doesn't detect the right mimetype and it
seems like I didn't bother to test this enough. So lets fix it for the
next release.

Fix #882 