### PR TITLE
Add missing catch blocks for migration from 1.1.1 to 1.2.0

### DIFF
--- a/lib/migrations/20150702001020-update-to-0_3_1.js
+++ b/lib/migrations/20150702001020-update-to-0_3_1.js
@@ -20,6 +20,12 @@ module.exports = {
         type: Sequelize.INTEGER,
         defaultValue: 0
       })
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'shortid'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20160112220142-note-add-lastchange.js
+++ b/lib/migrations/20160112220142-note-add-lastchange.js
@@ -7,6 +7,12 @@ module.exports = {
       return queryInterface.addColumn('Notes', 'lastchangeAt', {
         type: Sequelize.DATE
       })
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'lastchangeuserId'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20160420180355-note-add-alias.js
+++ b/lib/migrations/20160420180355-note-add-alias.js
@@ -7,6 +7,12 @@ module.exports = {
       return queryInterface.addIndex('Notes', ['alias'], {
         indicesType: 'UNIQUE'
       })
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'alias'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20160515114000-user-add-tokens.js
+++ b/lib/migrations/20160515114000-user-add-tokens.js
@@ -3,6 +3,12 @@ module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Users', 'accessToken', Sequelize.STRING).then(function () {
       return queryInterface.addColumn('Users', 'refreshToken', Sequelize.STRING)
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'accessToken'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20160607060246-support-revision.js
+++ b/lib/migrations/20160607060246-support-revision.js
@@ -15,6 +15,12 @@ module.exports = {
         createdAt: Sequelize.DATE,
         updatedAt: Sequelize.DATE
       })
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'savedAt'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20160703062241-support-authorship.js
+++ b/lib/migrations/20160703062241-support-authorship.js
@@ -16,6 +16,12 @@ module.exports = {
         createdAt: Sequelize.DATE,
         updatedAt: Sequelize.DATE
       })
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'authorship'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20161009040430-support-delete-note.js
+++ b/lib/migrations/20161009040430-support-delete-note.js
@@ -1,7 +1,13 @@
 'use strict'
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    return queryInterface.addColumn('Notes', 'deletedAt', Sequelize.DATE)
+    return queryInterface.addColumn('Notes', 'deletedAt', Sequelize.DATE).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'deletedAt'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
+    })
   },
 
   down: function (queryInterface, Sequelize) {

--- a/lib/migrations/20161201050312-support-email-signin.js
+++ b/lib/migrations/20161201050312-support-email-signin.js
@@ -2,7 +2,19 @@
 module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Users', 'email', Sequelize.TEXT).then(function () {
-      return queryInterface.addColumn('Users', 'password', Sequelize.TEXT)
+      return queryInterface.addColumn('Users', 'password', Sequelize.TEXT).catch(function (error) {
+        if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'password'") {
+          console.log('Migration has already run… ignoring.')
+        } else {
+          throw error
+        }
+      })
+    }).catch(function (error) {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'email'") {
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 


### PR DESCRIPTION
I found some problems when upgrading from 1.1.1 to 1.2.0 and all of them were related to duplicated keys. In my case, these changes solved the issue.

Thanks to @SISheogorath since it is based on pull request #877 