### PR TITLE
Upload images to the filesystem by default, rather than to imgur

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -139,7 +139,7 @@ if (config.sessionSecret === 'secret') {
 // Validate upload upload providers
 if (['filesystem', 's3', 'minio', 'imgur', 'azure'].indexOf(config.imageUploadType) === -1) {
   logger.error('"imageuploadtype" is not correctly set. Please use "filesystem", "s3", "minio", "azure" or "imgur". Defaulting to "imgur"')
-  config.imageUploadType = 'imgur'
+  config.imageUploadType = 'filesystem'
 }
 
 // figure out mime types for image uploads


### PR DESCRIPTION
Hi,

It's easy to fail to realize that images are uploaded to imgur by default (I just got bitten by this), and this can be an issue in some situations.
I wrote this trivial patch to default to a filesystem upload, in case others think the same.
Not sure if I should bump the version number though, let me know if it's the case!

I'll update the docs where needed if this PR gets the green light.