### PR TITLE
Support 'host' & 'path' config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ There are some config settings you need to change in the files below.
 | `DEBUG` | `true` or `false` | set debug mode; show more logs |
 | `CMD_DOMAIN` | `codimd.org` | domain name |
 | `CMD_URL_PATH` | `codimd` | sub URL path, like `www.example.com/<URL_PATH>` |
+| `CMD_HOST` | `localhost` | host to listen on |
 | `CMD_PORT` | `80` | web app port |
+| `CMD_PATH` | `/var/run/codimd.sock` | path to UNIX domain socket to listen on (if specified, `CMD_HOST` and `CMD_PORT` are ignored) |
 | `CMD_ALLOW_ORIGIN` | `localhost, codimd.org` | domain name whitelist (use comma to separate) |
 | `CMD_PROTOCOL_USESSL` | `true` or `false` | set to use SSL protocol for resources path (only applied when domain is set) |
 | `CMD_URL_ADDPORT` | `true` or `false` | set to add port on callback URL (ports `80` or `443` won't be applied) (only applied when domain is set) |
@@ -252,7 +254,9 @@ There are some config settings you need to change in the files below.
 | `debug` | `true` or `false` | set debug mode, show more logs |
 | `domain` | `localhost` | domain name |
 | `urlPath` | `codimd` | sub URL path, like `www.example.com/<urlpath>` |
+| `host` | `localhost` | host to listen on |
 | `port` | `80` | web app port |
+| `path` | `/var/run/codimd.sock` | path to UNIX domain socket to listen on (if specified, `host` and `port` are ignored) |
 | `allowOrigin` | `['localhost']` | domain name whitelist |
 | `useSSL` | `true` or `false` | set to use SSL server (if `true`, will auto turn on `protocolUseSSL`) |
 | `hsts` | `{"enable": true, "maxAgeSeconds": 31536000, "includeSubdomains": true, "preload": true}` | [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) options to use with HTTPS (default is the example value, max age is a year) |

--- a/app.js
+++ b/app.js
@@ -205,11 +205,21 @@ io.sockets.on('connection', realtime.connection)
 
 // listen
 function startListen () {
-  server.listen(config.port, function () {
+  var address
+  var listenCallback = function () {
     var schema = config.useSSL ? 'HTTPS' : 'HTTP'
-    logger.info('%s Server listening at port %d', schema, config.port)
+    logger.info('%s Server listening at %s', schema, address)
     realtime.maintenance = false
-  })
+  }
+
+  // use unix domain socket if 'path' is specified
+  if (config.path) {
+    address = config.path
+    server.listen(config.path, listenCallback)
+  } else {
+    address = config.host + ':' + config.port
+    server.listen(config.port, config.host, listenCallback)
+  }
 }
 
 // sync db then start listen

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -3,6 +3,7 @@
 module.exports = {
   domain: '',
   urlPath: '',
+  host: '0.0.0.0',
   port: 3000,
   urlAddPort: false,
   allowOrigin: ['localhost'],

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -5,7 +5,9 @@ const {toBooleanConfig, toArrayConfig, toIntegerConfig} = require('./utils')
 module.exports = {
   domain: process.env.CMD_DOMAIN,
   urlPath: process.env.CMD_URL_PATH,
+  host: process.env.CMD_HOST,
   port: toIntegerConfig(process.env.CMD_PORT),
+  path: process.env.CMD_PATH,
   urlAddPort: toBooleanConfig(process.env.CMD_URL_ADDPORT),
   useSSL: toBooleanConfig(process.env.CMD_USESSL),
   hsts: {


### PR DESCRIPTION
hi,

this patch adds two new config options to specify where the server listens (along with corresponding environment variables and documentation):

- `host`: specifies the host on which to listen, allowing restriction to a particular IP
- `path`: specifies the path to a unix domain socket on which to listen (takes precedence over `host`/`port`)