### PR TITLE
Fix possible weird objects as email

### DIFF
--- a/lib/letter-avatars.js
+++ b/lib/letter-avatars.js
@@ -27,6 +27,10 @@ exports.generateAvatar = function (name) {
 
 exports.generateAvatarURL = function (name, email = '', big = true) {
   let photo
+  if (typeof email !== 'string') {
+    email = '' + name + '@example.com'
+  }
+
   if (email !== '' && config.allowGravatar) {
     photo = 'https://www.gravatar.com/avatar/' + md5(email.toLowerCase())
     if (big) {


### PR DESCRIPTION
It seems like some providers return strange types for emails which cause
problems. We default to something that is definitely a string.

Fixes #903