### PR TITLE
Remove tests using node version 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         - export PATH="$HOME/.yarn/bin:$PATH"
     - env: task=npm-test
       node_js:
-        - 7
+        - 8
       before_install:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
         - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
Since node 7 is EOL and may breaks some new builds, we want to get rid of it. But having tests in version 8 would be nice, right? So here we go.