### PR TITLE
Extend migration error handling

### DIFF
--- a/lib/migrations/20150702001020-update-to-0_3_1.js
+++ b/lib/migrations/20150702001020-update-to-0_3_1.js
@@ -21,7 +21,7 @@ module.exports = {
         defaultValue: 0
       })
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'shortid'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'shortid'" || error.message === 'column "shortid" of relation "Notes" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20160112220142-note-add-lastchange.js
+++ b/lib/migrations/20160112220142-note-add-lastchange.js
@@ -8,7 +8,7 @@ module.exports = {
         type: Sequelize.DATE
       })
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'lastchangeuserId'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'lastchangeuserId'" || error.message === 'column "lastchangeuserId" of relation "Notes" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20160420180355-note-add-alias.js
+++ b/lib/migrations/20160420180355-note-add-alias.js
@@ -8,7 +8,7 @@ module.exports = {
         indicesType: 'UNIQUE'
       })
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'alias'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'alias'" || error.message === 'column "alias" of relation "Notes" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20160515114000-user-add-tokens.js
+++ b/lib/migrations/20160515114000-user-add-tokens.js
@@ -4,7 +4,7 @@ module.exports = {
     return queryInterface.addColumn('Users', 'accessToken', Sequelize.STRING).then(function () {
       return queryInterface.addColumn('Users', 'refreshToken', Sequelize.STRING)
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'accessToken'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'accessToken'" || error.message === 'column "accessToken" of relation "Users" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20160607060246-support-revision.js
+++ b/lib/migrations/20160607060246-support-revision.js
@@ -16,7 +16,7 @@ module.exports = {
         updatedAt: Sequelize.DATE
       })
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'savedAt'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'savedAt'" || error.message === 'column "savedAt" of relation "Notes" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20160703062241-support-authorship.js
+++ b/lib/migrations/20160703062241-support-authorship.js
@@ -17,7 +17,7 @@ module.exports = {
         updatedAt: Sequelize.DATE
       })
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'authorship'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'authorship'" || error.message === 'column "authorship" of relation "Notes" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20161009040430-support-delete-note.js
+++ b/lib/migrations/20161009040430-support-delete-note.js
@@ -2,7 +2,7 @@
 module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Notes', 'deletedAt', Sequelize.DATE).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'deletedAt'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'deletedAt'" || error.message === 'column "deletedAt" of relation "Notes" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error

--- a/lib/migrations/20161201050312-support-email-signin.js
+++ b/lib/migrations/20161201050312-support-email-signin.js
@@ -3,14 +3,14 @@ module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Users', 'email', Sequelize.TEXT).then(function () {
       return queryInterface.addColumn('Users', 'password', Sequelize.TEXT).catch(function (error) {
-        if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'password'") {
+        if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'password'" || error.message === 'column "password" of relation "Users" already exists') {
           console.log('Migration has already run… ignoring.')
         } else {
           throw error
         }
       })
     }).catch(function (error) {
-      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'email'") {
+      if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'email'" || error.message === 'column "email" of relation "Users" already exists') {
         console.log('Migration has already run… ignoring.')
       } else {
         throw error


### PR DESCRIPTION
The current error handling seems to conflict with some sequelize
versions. So we add a second version of it in our excemptions.

I'm not happy about it, but when it helps to prevent further migration
breaking, it's worth it.