### PR TITLE
Some minor improvements for setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,11 +8,12 @@ if [ -d .git ]; then
   cd "$(git rev-parse --show-toplevel)"
 fi
 
-if ! type npm > /dev/null
+if ! type yarn > /dev/null
 then
   cat << EOF
-npm is not installed, please install Node.js and npm.
+yarn is not installed, please install Node.js, npm and yarn.
 Read more on Node.js official website: https://nodejs.org
+And for yarn package manager at: https://yarnpkg.com/en/
 Setup will not be run
 EOF
   exit 0
@@ -27,8 +28,9 @@ if [ ! -f .sequelizerc ]; then
   cp .sequelizerc.example .sequelizerc
 fi
 
-echo "install npm packages"
-BUILD_ASSETS=false npm install
+echo "install packages"
+yarn install --pure-lockfile
+yarn install --production=false --pure-lockfile
 
 cat << EOF
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "webpack --config webpack.config.js --progress --colors --watch",
     "build": "webpack --config webpack.production.js --progress --colors --bail",
     "postinstall": "bin/heroku",
-    "start": "node app.js",
+    "start": "sequelize db:migrate && node app.js",
     "doctoc": "doctoc --title='# Table of Contents' README.md"
   },
   "dependencies": {


### PR DESCRIPTION
Since we use `yarn` for our container setup and try to enforce
dependencies, we should also use yarn in the setup script.