### PR TITLE
Replace `uws` with `ws` package

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ app.use(morgan('combined', {
 
 // socket io
 var io = require('socket.io')(server)
-io.engine.ws = new (require('uws').Server)({
+io.engine.ws = new (require('ws').Server)({
   noServer: true,
   perMessageDeflate: false
 })

--- a/package.json
+++ b/package.json
@@ -125,12 +125,12 @@
     "to-markdown": "^3.0.3",
     "toobusy-js": "^0.5.1",
     "uuid": "^3.1.0",
-    "uws": "~0.14.1",
     "validator": "^10.4.0",
     "velocity-animate": "^1.4.0",
     "visibilityjs": "^1.2.4",
     "viz.js": "^1.7.0",
     "winston": "^2.3.0",
+    "ws": "^6.0.0",
     "xss": "^1.0.3"
   },
   "engines": {
@@ -211,5 +211,9 @@
       "lib/ot",
       "public/vendor"
     ]
+  },
+  "optionalDependencies": {
+    "bufferutil": "^4.0.0",
+    "utf-8-validate": "^5.0.1"
   }
 }


### PR DESCRIPTION
`uws` was deprecated by its maintainer and starts to cause more and more
problems and issue reports. So it's time to replace it and use a
maintained project instead. Lucky us, `uws` and `ws` can be used in an
identical way, without problems. To provide better performance, we
install the optional packages as well.