### PR TITLE
Use OS based tmp dir

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const os = require('os')
+
 module.exports = {
   domain: '',
   urlPath: '',
@@ -39,7 +41,7 @@ module.exports = {
   dhParamPath: '',
   // other path
   viewPath: './public/views',
-  tmpPath: './tmp',
+  tmpPath: os.tmpdir(),
   defaultNotePath: './public/default.md',
   docsPath: './public/docs',
   uploadsPath: './public/uploads',


### PR DESCRIPTION
We should use the official OS temp directory instead of an own one, to
not run into conflicts. Also various dependencies already use the OS
temp directory, which makes it pointless to use a different for our
internal purposes then. This commit provides the changes needed to use
the OS tmp directory by default.