### PR TITLE
Fix server crash on PDF creation

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -341,6 +341,10 @@ function actionPDF (req, res, note) {
   var path = config.tmpPath + '/' + Date.now() + '.pdf'
   content = content.replace(/\]\(\//g, '](' + url + '/')
   markdownpdf().from.string(content).to(path, function () {
+    if (!fs.existsSync(path)) {
+      logger.error('PDF seems to not be generated as expected. File doesn\'t exist: ' + path)
+      return response.errorInternalError(res)
+    }
     var stream = fs.createReadStream(path)
     var filename = title
     // Be careful of special characters


### PR DESCRIPTION
`markdown-pdf` seems to fail to provide the PDFs on tmpfs. This leads
crashing codimd which expects the file to be there. This patch should
add some proper error handling when expectation and reality don't fit
together.