### PR TITLE
Omit unneeded warning if no gitlab is configured

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -104,7 +104,7 @@ config.isOAuth2Enable = config.oauth2.clientID && config.oauth2.clientSecret
 config.isPDFExportEnable = config.allowPDFExport
 
 // Check gitlab api version
-if (config.gitlab.version !== 'v4' && config.gitlab.version !== 'v3') {
+if (config.gitlab && config.gitlab.version !== 'v4' && config.gitlab.version !== 'v3') {
   logger.warn('config.js contains wrong version (' + config.gitlab.version + ') for gitlab api; it should be \'v3\' or \'v4\'. Defaulting to v4')
   config.gitlab.version = 'v4'
 }


### PR DESCRIPTION
This patch should fix the unneeded warning of the wrong API version,
when gitlab isn't configured at all.