### PR TITLE
Fix document length limit on post

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -32,6 +32,9 @@ var response = {
   errorBadRequest: function (res) {
     responseError(res, '400', 'Bad Request', 'something not right.')
   },
+  errorTooLong: function (res) {
+    responseError(res, '413', 'Payload Too Large', 'Shorten your note!')
+  },
   errorInternalError: function (res) {
     responseError(res, '500', 'Internal Error', 'wtf.')
   },
@@ -145,7 +148,12 @@ function responseCodiMD (res, note) {
 
 function newNote (req, res, next) {
   var owner = null
-  var body = req.body ? req.body : ''
+  var body = ''
+  if (req.body && req.body.length > config.documentMaxLength) {
+    return response.errorTooLong(res)
+  } else {
+    body = req.body
+  }
   body = body.replace(/[\r]/g, '')
   if (req.isAuthenticated()) {
     owner = req.user.id


### PR DESCRIPTION
We recently introduced a new way to create notes using a post request
to the `/new` endpoint. This is not limited in size, other than pasting
a note in the editor. This patch should enforce this limit also on this
way.