### PR TITLE
Add POEditor to 'follow us' statement

### DIFF
--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -153,7 +153,7 @@
                         &copy; 2018 <a href="https://hackmd.io">CodiMD</a> | <a href="<%- url %>/s/release-notes" target="_blank"><%= __('Releases') %></a><% if(privacyStatement) { %> | <a href="<%- url %>/s/privacy" target="_blank"><%= __('Privacy') %></a><% } %><% if(termsOfUse) { %> | <a href="<%- url %>/s/terms-of-use" target="_blank"><%= __('Terms of Use') %></a><% } %>
                     </p>
                     <h6 class="social-foot">
-                        <%- __('Follow us on %s and %s.', '<a href="https://github.com/hackmdio/CodiMD" target="_blank"><i class="fa fa-github"></i> GitHub</a>, <a href="https://riot.im/app/#/room/#codimd:matrix.org" target="_blank"><i class="fa fa-comments"></i> Riot</a>') %>
+                        <%- __('Follow us on %s and %s.', '<a href="https://github.com/hackmdio/CodiMD" target="_blank"><i class="fa fa-github"></i> GitHub</a>, <a href="https://riot.im/app/#/room/#codimd:matrix.org" target="_blank"><i class="fa fa-comments"></i> Riot</a>', '<a href="https://translate.codimd.org" target="_blank"><i class="fa fa-globe"></i> POEditor</a>') %>
                     </h6>
                 </div>
             </div>


### PR DESCRIPTION
We broke the follow us before by removing Facebook and Twitter. Adding
POEditor should fix it and help to attract new translators.