### PR TITLE
Replace youtube example video on features page

### DIFF
--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -195,7 +195,7 @@ When you’re a carpenter making a beautiful chest of drawers, you’re not goin
 ## Externals
 
 ### YouTube
-{%youtube 1G4isv_Fylg %}
+{%youtube aqz-KE-bpKQ %}
 
 ### Vimeo
 {%vimeo 124148255 %}


### PR DESCRIPTION
Since the youtube video on our feature page seems to have vanished, this
patch replaces it with an video of the blender foundation.