### PR TITLE
Add asciinema integration

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -5,7 +5,7 @@ var CspStrategy = {}
 
 var defaultDirectives = {
   defaultSrc: ['\'self\''],
-  scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net', 'https://query.yahooapis.com', '\'unsafe-eval\''],
+  scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net', 'https://query.yahooapis.com', 'https://asciinema.org/', '\'unsafe-eval\''],
   // ^ TODO: Remove unsafe-eval - webpack script-loader issues https://github.com/hackmdio/codimd/issues/594
   imgSrc: ['*'],
   styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://assets-cdn.github.com'], // unsafe-inline is required for some libs, plus used in views

--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -209,6 +209,9 @@ When you’re a carpenter making a beautiful chest of drawers, you’re not goin
 ### Speakerdeck
 {%speakerdeck sugarenia/xxlcss-how-to-scale-css-and-keep-your-sanity %}
 
+### Asciinema
+{%asciinema 32324 %}
+
 ### PDF
 **Caution: this might be blocked by your browser if not using an `https` URL.**
 {%pdf https://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf %}

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -497,6 +497,18 @@ export function finishView (view) {
                 height: '400px'
               })
             })
+    // asciinema
+  view.find('div.asciinema.raw').removeClass('raw')
+        .click(function () {
+          console.log(this)
+          if (!$(this).attr('data-recordingid')) return
+
+          const script = $('<script async></script>')
+          $(script).attr('src', `https://asciinema.org/a/${$(this).attr('data-recordingid')}.js?autoplay=1`)
+          $(script).attr('id', `asciicast-${$(this).attr('data-recordingid')}`)
+          $(this).find('img').addClass('hidden')
+          $(this).append(script)
+        })
     // syntax highlighting
   view.find('code.raw').removeClass('raw')
         .each((key, value) => {
@@ -1143,6 +1155,23 @@ const pdfPlugin = new Plugin(
     }
 )
 
+const asciinemaPlugin = new Plugin(
+    // regexp to match
+    /{%asciinema\s*([\d\D]*?)\s*%}/,
+
+    (match, utils) => {
+      const recordingid = match[1]
+      if (!recordingid) return
+
+      const div = $('<div class="asciinema raw"></div>')
+      div.attr('data-recordingid', recordingid)
+      const thumbnailSrc = `https://asciinema.org/a/${recordingid}.png`
+      const image = `<img src="${thumbnailSrc}" />`
+      div.append(image)
+      return div[0].outerHTML
+    }
+)
+
 // yaml meta, from https://github.com/eugeneware/remarkable-meta
 function get (state, line) {
   const pos = state.bMarks[line]
@@ -1194,6 +1223,7 @@ md.use(tocPlugin)
 md.use(slidesharePlugin)
 md.use(speakerdeckPlugin)
 md.use(pdfPlugin)
+md.use(asciinemaPlugin)
 
 export default {
   md

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -824,7 +824,7 @@ function imgPlayiframe (element, src) {
   if (!$(element).attr('data-videoid')) return
   const iframe = $("<iframe frameborder='0' webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>")
   $(iframe).attr('src', `${src + $(element).attr('data-videoid')}?autoplay=1`)
-  $(element).find('img').css('visibility', 'hidden')
+  $(element).find('img').addClass('invisible')
   $(element).append(iframe)
 }
 


### PR DESCRIPTION
This PR is a working implementation for an asciinema integration. But due to security concerns it should be rewritten to not dynamically embed external JS from https://asciinema.org.

Instead we should try to rewrite this to use [asciinema-player](https://github.com/asciinema/asciinema-player) instead which is also [available on CDNJS](https://cdnjs.com/libraries/asciinema-player).

Feel free to pick this up and figure it out during Hacktober :)