### PR TITLE
Add development mode for webpack in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run-script standard && npm run-script jsonlint",
     "jsonlint": "find . -not -path './node_modules/*' -type f -name '*.json' -o -type f -name '*.json.example' | while read json; do echo $json ; jq . $json; done",
     "standard": "node ./node_modules/standard/bin/cmd.js",
-    "dev": "webpack --config webpack.config.js --progress --colors --watch",
+    "dev": "webpack --config webpack.config.js --mode=production --progress --colors --watch",
     "build": "webpack --config webpack.production.js --progress --colors --bail",
     "postinstall": "bin/heroku",
     "start": "node app.js",


### PR DESCRIPTION
Seems like we have to explicitly tell the new webpack version that we
want to use the development environment. This provides us with source
maps and similar.

This patch adds the commandline option in our scripts in package.json