### PR TITLE
Fix some webpack issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run-script standard && npm run-script jsonlint",
     "jsonlint": "find . -not -path './node_modules/*' -type f -name '*.json' -o -type f -name '*.json.example' | while read json; do echo $json ; jq . $json; done",
     "standard": "node ./node_modules/standard/bin/cmd.js",
-    "dev": "webpack --config webpack.config.js --mode=production --progress --colors --watch",
+    "dev": "webpack --config webpack.config.js --progress --colors --watch",
     "build": "webpack --config webpack.production.js --progress --colors --bail",
     "postinstall": "bin/heroku",
     "start": "node app.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,13 @@ module.exports = [Object.assign({}, baseConfig, {
     })
 
   ]),
-  devtool: 'source-map'
+  devtool: 'source-map',
+  optimization: {
+    removeAvailableModules: false,
+    removeEmptyChunks: false,
+    splitChunks: false
+  },
+  mode: 'development'
 }), {
   devtool: 'source-map',
   entry: {

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -11,7 +11,12 @@ module.exports = [Object.assign({}, baseConfig, {
       'process.env': {
         'NODE_ENV': JSON.stringify('production')
       }
+    }),
+    new MiniCssExtractPlugin({
+      filename: '[name].[hash].css',
+      chunkFilename: '[id].css'
     })
+
   ]),
 
   optimization: {
@@ -30,9 +35,10 @@ module.exports = [Object.assign({}, baseConfig, {
   output: {
     path: path.join(__dirname, 'public/build'),
     publicPath: '/build/',
-    filename: '[id].[name].[hash].js'
+    filename: '[name].[hash].js'
     // baseUrl: '<%- url %>'
-  }
+  },
+  mode: 'production'
 }), {
   // This Chunk is used in the 'save as html' feature.
   // It is embedded in the html file and contains CSS for styling.

--- a/webpackBaseConfig.js
+++ b/webpackBaseConfig.js
@@ -165,8 +165,7 @@ module.exports = {
         from: 'plugin',
         to: 'reveal.js/plugin'
       }
-    ]),
-    new MiniCssExtractPlugin()
+    ])
   ],
 
   entry: {


### PR DESCRIPTION
We should use hashes for production builds. This prevents problems
during upgrades. At the same time, disable various optimizations and
features of webpack during development builds to speedup development
builds.

/cc @davidmehren 