### PR TITLE
Add `data:` URL to CSP and upgrade helmet

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -9,7 +9,7 @@ var defaultDirectives = {
   // ^ TODO: Remove unsafe-eval - webpack script-loader issues https://github.com/hackmdio/codimd/issues/594
   imgSrc: ['*'],
   styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://assets-cdn.github.com'], // unsafe-inline is required for some libs, plus used in views
-  fontSrc: ['\'self\'', 'https://public.slidesharecdn.com'],
+  fontSrc: ['\'self\'', 'data:', 'https://public.slidesharecdn.com'],
   objectSrc: ['*'], // Chrome PDF viewer treats PDFs as objects :/
   mediaSrc: ['*'],
   childSrc: ['*'],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gist-embed": "~2.6.0",
     "graceful-fs": "^4.1.11",
     "handlebars": "^4.0.6",
-    "helmet": "^3.3.0",
+    "helmet": "^3.13.0",
     "highlight.js": "~9.12.0",
     "i18n": "^0.8.3",
     "imgur": "git+https://github.com/hackmdio/node-imgur.git",


### PR DESCRIPTION
Seems like the old version of helmet had a problem with `data:`. This
patch upgrades to the latest version and adds the CSP rule to allow
Google Fonts and the offline version of it, to properly include the
fonts and no longer throw ugly error messages at us.