### PR TITLE
Remove dead package octicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "morgan": "^1.7.0",
     "mysql": "^2.12.0",
     "node-uuid": "^1.4.7",
-    "octicons": "~4.4.0",
     "passport": "^0.4.0",
     "passport-dropbox-oauth2": "^1.1.0",
     "passport-facebook": "^2.1.1",

--- a/public/css/github-extract.css
+++ b/public/css/github-extract.css
@@ -119,23 +119,24 @@
     color: #ddd;
 }
 
-.markdown-body h1 .octicon-link,
-.markdown-body h2 .octicon-link,
-.markdown-body h3 .octicon-link,
-.markdown-body h4 .octicon-link,
-.markdown-body h5 .octicon-link,
-.markdown-body h6 .octicon-link {
+.markdown-body h1 .fa-link,
+.markdown-body h2 .fa-link,
+.markdown-body h3 .fa-link,
+.markdown-body h4 .fa-link,
+.markdown-body h5 .fa-link,
+.markdown-body h6 .fa-link {
     color: #000;
     vertical-align: middle;
     visibility: hidden;
+    font-size: 16px;
 }
 
-.night .markdown-body h1 .octicon-link,
-.night .markdown-body h2 .octicon-link,
-.night .markdown-body h3 .octicon-link,
-.night .markdown-body h4 .octicon-link,
-.night .markdown-body h5 .octicon-link,
-.night .markdown-body h6 .octicon-link {
+.night .markdown-body h1 .fa-link,
+.night .markdown-body h2 .fa-link,
+.night .markdown-body h3 .fa-link,
+.night .markdown-body h4 .fa-link,
+.night .markdown-body h5 .fa-link,
+.night .markdown-body h6 .fa-link {
     color: #fff;
 }
 
@@ -148,12 +149,12 @@
     text-decoration: none;
 }
 
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
+.markdown-body h1:hover .anchor .fa-link,
+.markdown-body h2:hover .anchor .fa-link,
+.markdown-body h3:hover .anchor .fa-link,
+.markdown-body h4:hover .anchor .fa-link,
+.markdown-body h5:hover .anchor .fa-link,
+.markdown-body h6:hover .anchor .fa-link {
     visibility: visible;
 }
 

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -834,7 +834,7 @@ const anchorForId = id => {
   const anchor = document.createElement('a')
   anchor.className = 'anchor hidden-xs'
   anchor.href = `#${id}`
-  anchor.innerHTML = '<span class="octicon octicon-link"></span>'
+  anchor.innerHTML = '<i class="fa fa-link"></i>'
   anchor.title = id
   return anchor
 }

--- a/public/views/codimd/head.ejs
+++ b/public/views/codimd/head.ejs
@@ -12,7 +12,6 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/4.9.0/bootstrap-social.min.css" integrity="sha256-02JtFTurpwBjQJ6q13iJe82/NF0RbZlJroDegK5g87Y=" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css" integrity="sha256-3iu9jgsy9TpTwXKb7bNQzqWekRX7pPK+2OLj3R922fo=" crossorigin="anonymous" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/4.4.0/octicons.min.css" integrity="sha256-4eCms8tUm+iL29tUvmRhNRnz/7lNI4oTtQzqa/uM2dI=" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/emojify.js/1.1.0/css/basic/emojify.min.css" integrity="sha256-UOrvMOsSDSrW6szVLe8ZDZezBxh5IoIfgTwdNDgTjiU=" crossorigin="anonymous" />
 <%- include ../build/index-header %>
 <%- include ../shared/polyfill %>

--- a/public/views/html.hbs
+++ b/public/views/html.hbs
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css" integrity="sha256-3iu9jgsy9TpTwXKb7bNQzqWekRX7pPK+2OLj3R922fo=" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/4.4.0/octicons.min.css" integrity="sha256-4eCms8tUm+iL29tUvmRhNRnz/7lNI4oTtQzqa/uM2dI=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github-gist.min.css" integrity="sha256-tAflq+ymku3Khs+I/WcAneIlafYgDiOQ9stIHH985Wo=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/emojify.js/1.1.0/css/basic/emojify.min.css" integrity="sha256-UOrvMOsSDSrW6szVLe8ZDZezBxh5IoIfgTwdNDgTjiU=" crossorigin="anonymous" />

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -21,7 +21,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css" integrity="sha256-3iu9jgsy9TpTwXKb7bNQzqWekRX7pPK+2OLj3R922fo=" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/4.4.0/octicons.min.css" integrity="sha256-4eCms8tUm+iL29tUvmRhNRnz/7lNI4oTtQzqa/uM2dI=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/emojify.js/1.1.0/css/basic/emojify.min.css" integrity="sha256-UOrvMOsSDSrW6szVLe8ZDZezBxh5IoIfgTwdNDgTjiU=" crossorigin="anonymous" />
     <%- include build/pretty-header %>
     <%- include shared/polyfill %>

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -18,7 +18,6 @@
         <% if(useCDN) { %>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css" integrity="sha256-3iu9jgsy9TpTwXKb7bNQzqWekRX7pPK+2OLj3R922fo=" crossorigin="anonymous" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/4.4.0/octicons.min.css" integrity="sha256-4eCms8tUm+iL29tUvmRhNRnz/7lNI4oTtQzqa/uM2dI=" crossorigin="anonymous" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.6.0/css/reveal.min.css" integrity="sha256-ol2N5Xr80jdDqxK0lte3orKGb9Ja3sOnpAUV7TTADmg=" crossorigin="anonymous" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/emojify.js/1.1.0/css/basic/emojify.min.css" integrity="sha256-UOrvMOsSDSrW6szVLe8ZDZezBxh5IoIfgTwdNDgTjiU=" crossorigin="anonymous" />
         <%- include build/slide-header %>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -239,8 +239,7 @@ module.exports = {
       path.join(__dirname, 'node_modules/bootstrap/dist/css/bootstrap.min.css'),
       path.join(__dirname, 'node_modules/fork-awesome/css/fork-awesome.min.css'),
       path.join(__dirname, 'public/css/bootstrap-social.css'),
-      path.join(__dirname, 'node_modules/ionicons/css/ionicons.min.css'),
-      path.join(__dirname, 'node_modules/octicons/build/octicons.css')
+      path.join(__dirname, 'node_modules/ionicons/css/ionicons.min.css')
     ],
     'index-pack': [
       'babel-polyfill',
@@ -289,8 +288,7 @@ module.exports = {
     'pretty-styles-pack': [
       path.join(__dirname, 'node_modules/bootstrap/dist/css/bootstrap.min.css'),
       path.join(__dirname, 'node_modules/fork-awesome/css/fork-awesome.min.css'),
-      path.join(__dirname, 'node_modules/ionicons/css/ionicons.min.css'),
-      path.join(__dirname, 'node_modules/octicons/build/octicons.css')
+      path.join(__dirname, 'node_modules/ionicons/css/ionicons.min.css')
     ],
     'pretty-pack': [
       'babel-polyfill',
@@ -326,8 +324,7 @@ module.exports = {
     ],
     'slide-styles-pack': [
       path.join(__dirname, 'node_modules/fork-awesome/css/fork-awesome.min.css'),
-      path.join(__dirname, 'node_modules/ionicons/css/ionicons.min.css'),
-      path.join(__dirname, 'node_modules/octicons/build/octicons.css')
+      path.join(__dirname, 'node_modules/ionicons/css/ionicons.min.css')
     ],
     'slide-pack': [
       'babel-polyfill',


### PR DESCRIPTION
Octicon no longer provides its CSS classes and this way is useless in
CodiMD. Replacing all used classes in the UI and remove it from build
system.
