### PR TITLE
Make oauth2 provider name accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ There are some config settings you need to change in the files below.
 | `CMD_OAUTH2_AUTHORIZATION_URL` | `https://example.com` | authorization URL of your provider, please refer to the documentation of your OAuth2 provider (no default value) |
 | `CMD_OAUTH2_CLIENT_ID` | `afae02fckafd...` | you will get this from your OAuth2 provider when you register CodiMD as OAuth2-client, (no default value) |
 | `CMD_OAUTH2_CLIENT_SECRET` | `afae02fckafd...` | you will get this from your OAuth2 provider when you register CodiMD as OAuth2-client, (no default value) |
+| `CMD_OAUTH2_PROVIDERNAME` | `My institution` | Optional name to be displayed at login form indicating the oAuth2 provider |
 | `CMD_IMGUR_CLIENTID` | no example | Imgur API client id |
 | `CMD_EMAIL` | `true` or `false` | set to allow email signin |
 | `CMD_ALLOW_PDF_EXPORT` | `true` or `false` | Enable or disable PDF exports |

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -83,6 +83,7 @@ module.exports = {
   },
   // authentication
   oauth2: {
+    providerName: undefined,
     authorizationURL: undefined,
     tokenURL: undefined,
     clientID: undefined,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -75,6 +75,7 @@ module.exports = {
     clientSecret: process.env.CMD_MATTERMOST_CLIENTSECRET
   },
   oauth2: {
+    providerName: process.env.CMD_OAUTH2_PROVIDERNAME,
     baseURL: process.env.CMD_OAUTH2_BASEURL,
     userProfileURL: process.env.CMD_OAUTH2_USER_PROFILE_URL,
     userProfileUsernameAttr: process.env.CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR,


### PR DESCRIPTION
Right now the feature exists but is almost not usable since the only way
to configure it is to know that it exists from reading the source code
and add it to config.json. This patch provides all needed changes so it
can be used by everyone including documentation.