### PR TITLE
Add full version string (and no AGPL violation detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ There are some config settings you need to change in the files below.
 | `CMD_HSTS_PRELOAD` | `true` | whether to allow preloading of the site's HSTS status (e.g. into browsers) |
 | `CMD_CSP_ENABLE` | `true` | whether to enable Content Security Policy (directives cannot be configured with environment variables) |
 | `CMD_CSP_REPORTURI` | `https://<someid>.report-uri.com/r/d/csp/enforce` | Allows to add a URL for CSP reports in case of violations |
+| `CMD_SOURCE_URL` | `https://github.com/hackmdio/codimd/tree/<current commit>` | Provides the link to the source code of CodiMD on the entry page (Please, make sure you change this when you run a modified version) |
 
 ***Note:** Due to the rename process we renamed all `HMD_`-prefix variables to be `CMD_`-prefixed. The old ones continue to work.*
 
@@ -310,6 +311,7 @@ There are some config settings you need to change in the files below.
 | `minio` | `{ "accessKey": "YOUR_MINIO_ACCESS_KEY", "secretKey": "YOUR_MINIO_SECRET_KEY", "endpoint": "YOUR_MINIO_HOST", port: 9000, secure: true }` | When `imageUploadType` is set to `minio`, you need to set this key. Also checkout our [Minio Image Upload Guide](docs/guides/minio-image-upload.md) |
 | `s3` | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION" }` | When `imageuploadtype` be set to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
 | `s3bucket` | `YOUR_S3_BUCKET_NAME` | bucket name when `imageUploadType` is set to `s3` or `minio` |
+| `sourceURL` | `https://github.com/hackmdio/codimd/tree/<current commit>` | Provides the link to the source code of CodiMD on the entry page (Please, make sure you change this when you run a modified version) |
 
 <sup>1</sup>: relative paths are based on CodiMD's base directory
 

--- a/app.js
+++ b/app.js
@@ -178,6 +178,7 @@ app.set('view engine', 'ejs')
 // set generally available variables for all views
 app.locals.useCDN = config.useCDN
 app.locals.serverURL = config.serverURL
+app.locals.sourceURL = config.sourceURL
 app.locals.allowAnonymous = config.allowAnonymous
 app.locals.allowAnonymousEdits = config.allowAnonymousEdits
 app.locals.allowPDFExport = config.allowPDFExport

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -3,6 +3,7 @@
 const {toBooleanConfig, toArrayConfig, toIntegerConfig} = require('./utils')
 
 module.exports = {
+  sourceURL: process.env.CMD_SOURCE_URL,
   domain: process.env.CMD_DOMAIN,
   urlPath: process.env.CMD_URL_PATH,
   host: process.env.CMD_HOST,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -8,6 +8,7 @@ const {merge} = require('lodash')
 const deepFreeze = require('deep-freeze')
 const {Environment, Permission} = require('./enum')
 const logger = require('../logger')
+const {getGitCommit, getGitHubURL} = require('./utils')
 
 const appRootPath = path.resolve(__dirname, '../../')
 const env = process.env.NODE_ENV || Environment.development
@@ -16,11 +17,17 @@ const debugConfig = {
 }
 
 // Get version string from package.json
-const {version} = require(path.join(appRootPath, 'package.json'))
+const {version, repository} = require(path.join(appRootPath, 'package.json'))
+
+const commitID = getGitCommit(appRootPath)
+const sourceURL = getGitHubURL(repository.url, commitID || version)
+const fullversion = commitID ? `${version}-${commitID}` : version
 
 const packageConfig = {
   version: version,
-  minimumCompatibleVersion: '0.5.0'
+  minimumCompatibleVersion: '0.5.0',
+  fullversion: fullversion,
+  sourceURL: sourceURL
 }
 
 const configFilePath = path.resolve(appRootPath, process.env.CMD_CONFIG_FILE ||

--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
+
 exports.toBooleanConfig = function toBooleanConfig (configValue) {
   if (configValue && typeof configValue === 'string') {
     return (configValue === 'true')
@@ -19,4 +22,34 @@ exports.toIntegerConfig = function toIntegerConfig (configValue) {
     return parseInt(configValue)
   }
   return configValue
+}
+
+exports.getGitCommit = function getGitCommit (repodir) {
+  if (!fs.existsSync(repodir + '/.git/HEAD')) {
+    return undefined
+  }
+  let reference = fs.readFileSync(repodir + '/.git/HEAD', 'utf8')
+  if (reference.startsWith('ref: ')) {
+    reference = reference.substr(5).replace('\n', '')
+    reference = fs.readFileSync(path.resolve(repodir + '/.git', reference), 'utf8')
+  }
+  reference = reference.substr(5).replace('\n', '')
+  return reference
+}
+
+exports.getGitHubURL = function getGitHubURL (repo, reference) {
+  // if it's not a github reference, we handle handle that anyway
+  if (!repo.startsWith('https://github.com') && !repo.startsWith('git@github.com')) {
+    return repo
+  }
+  if (repo.startsWith('git@github.com') || repo.startsWith('ssh://git@github.com')) {
+    repo = repo.replace(/^(ssh:\/\/)?git@github.com:/, 'https://github.com/')
+  }
+
+  if (repo.endsWith('.git')) {
+    repo = repo.replace(/\.git$/, '/')
+  } else if (!repo.endsWith('/')) {
+    repo = repo + '/'
+  }
+  return repo + 'tree/' + reference
 }

--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -887,7 +887,7 @@ function connection (socket) {
   // check version
   socket.on('version', function () {
     socket.emit('version', {
-      version: config.version,
+      version: config.fullversion,
       minimumCompatibleVersion: config.minimumCompatibleVersion
     })
   })

--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -96,7 +96,7 @@ statusRouter.get('/config', function (req, res) {
     domain: config.domain,
     urlpath: config.urlPath,
     debug: config.debug,
-    version: config.version,
+    version: config.fullversion,
     DROPBOX_APP_KEY: config.dropbox.appKey,
     allowedUploadMimeTypes: config.allowedUploadMimeTypes
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -112,5 +112,6 @@
 	"This will delete your account, all notes that are owned by you and remove all references to your account from other notes.": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes.",
 	"Delete user": "Delete user",
 	"Export user data": "Export user data",
-	"Help us translating on %s": "Help us translating on %s"
+	"Help us translating on %s": "Help us translating on %s",
+	"Source Code": "Source Code"
 }

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -150,7 +150,7 @@
                         <option value="id">Bahasa Indonesia</option>
                     </select>
                     <p>
-                        Powered by <a href="https://codimd.org">CodiMD</a> | <a href="<%- serverURL %>/s/release-notes" target="_blank" rel="noopener"><%= __('Releases') %></a><% if(privacyStatement) { %> | <a href="<%- serverURL %>/s/privacy" target="_blank" rel="noopener"><%= __('Privacy') %></a><% } %><% if(termsOfUse) { %> | <a href="<%- serverURL %>/s/terms-of-use" target="_blank" rel="noopener"><%= __('Terms of Use') %></a><% } %>
+                        Powered by <a href="https://codimd.org">CodiMD</a> | <a href="<%- serverURL %>/s/release-notes" target="_blank" rel="noopener"><%= __('Releases') %></a>| <a href="<%- sourceURL %>" target="_blank" rel="noopener"><%= __('Source Code') %></a><% if(privacyStatement) { %> | <a href="<%- serverURL %>/s/privacy" target="_blank" rel="noopener"><%= __('Privacy') %></a><% } %><% if(termsOfUse) { %> | <a href="<%- serverURL %>/s/terms-of-use" target="_blank" rel="noopener"><%= __('Terms of Use') %></a><% } %>
                     </p>
                     <h6 class="social-foot">
                         <%- __('Follow us on %s and %s.', '<a href="https://github.com/hackmdio/CodiMD" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub</a>, <a href="https://riot.im/app/#/room/#codimd:matrix.org" target="_blank" rel="noopener"><i class="fa fa-comments"></i> Riot</a>', '<a href="https://translate.codimd.org" target="_blank" rel="noopener"><i class="fa fa-globe"></i> POEditor</a>') %>


### PR DESCRIPTION
Currently we only provide the version from `package.json`. This means
that during updates of instances, e.g. the demo instance, which runs
latest master instead of a stable release, changes are not reflected to
the webclient.

This patch adds a fullversion string that contains the current commit
and this way makes that clients are notified about changes.

Also adds an automated detection for AGPL clear violations and asks the user for fixing it in production environments.