### PR TITLE
Update supported node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Just to more confusion: We are still friends with HackMD :heart:
 
 ### Prerequisite
 
-- Node.js 6.x or up (test up to 7.5.0)
+- Node.js 6.x or up (test up to 7.5.0) and <10.x
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm (and its dependencies, especially [uWebSockets](https://github.com/uWebSockets/uWebSockets#nodejs-developers), [node-gyp](https://github.com/nodejs/node-gyp#installation))
 - For **building** CodiMD we recommend to use a machine with at least **2GB** RAM


### PR DESCRIPTION
Support includes v9.x, but no v10.x

Console message:
```
error CodiMD@1.2.1: The engine "node" is incompatible with this module. Expected version ">=6.x <10.x". Got "10.11.0"
```
https://github.com/nodejs/Release
Node.js LTS 10.x starts in October and i saw no PR to change compatible version