### PR TITLE
slide example: Add link to slide printing instructions

### DIFF
--- a/public/docs/slide-example.md
+++ b/public/docs/slide-example.md
@@ -270,7 +270,7 @@ Press `B` or `.` on your keyboard to pause the presentation. This is helpful whe
 
 Down below you can find a print icon<i class="fa fa-fw fa-print"></i>.
 
-After you click on it, use the print function of your browser (either CTRL+P or cmd+P) to print the slides as PDF.
+After you click on it, use the print function of your browser (either CTRL+P or cmd+P) to print the slides as PDF. [See official reveal.js instructions for details](https://github.com/hakimel/reveal.js#instructions-1)
 
 ---
 


### PR DESCRIPTION
The printing instructions seem to not be really clear. Linking the
reveal.js offical docs should help.