### PR TITLE
Fix #986 : Visibility is now transmitted with gitlab V4 api

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1479,7 +1479,7 @@ $('#snippetExportModalConfirm').click(function () {
     file_name: $('#snippetExportModalFileName').val(),
     code: editor.getValue(),
     visibility_level: $('#snippetExportModalVisibility').val(),
-    visibility: $('#snippetExportModalVisibility').val() === 0 ? 'private' : ($('#snippetExportModalVisibility').val() === 10 ? 'internal' : '')
+    visibility: $('#snippetExportModalVisibility').val() === '0' ? 'private' : ($('#snippetExportModalVisibility').val() === '10' ? 'internal' : 'private')
   }
 
   if (!data.title || !data.file_name || !data.code || !data.visibility_level || !$('#snippetExportModalProjects').val()) return


### PR DESCRIPTION
The test was not on the right type, so the Visibility attribute was always empty.
This PR fix the test and gives a default value ("private") for Visibility of snippets.