### PR TITLE
Add autocomplete for highlight.js languages into codemirror

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -17,6 +17,7 @@ import toMarkdown from 'to-markdown'
 import { saveAs } from 'file-saver'
 import randomColor from 'randomcolor'
 import store from 'store'
+import hljs from 'highlight.js'
 
 import _ from 'lodash'
 
@@ -92,7 +93,7 @@ var cursorMenuThrottle = 50
 var cursorActivityDebounce = 50
 var cursorAnimatePeriod = 100
 var supportContainers = ['success', 'info', 'warning', 'danger']
-var supportCodeModes = ['javascript', 'typescript', 'jsx', 'htmlmixed', 'htmlembedded', 'css', 'xml', 'clike', 'clojure', 'ruby', 'python', 'shell', 'php', 'sql', 'haskell', 'coffeescript', 'yaml', 'pug', 'lua', 'cmake', 'nginx', 'perl', 'sass', 'r', 'dockerfile', 'tiddlywiki', 'mediawiki', 'go', 'gherkin']
+var supportCodeModes = ['javascript', 'typescript', 'jsx', 'htmlmixed', 'htmlembedded', 'css', 'xml', 'clike', 'clojure', 'ruby', 'python', 'shell', 'php', 'sql', 'haskell', 'coffeescript', 'yaml', 'pug', 'lua', 'cmake', 'nginx', 'perl', 'sass', 'r', 'dockerfile', 'tiddlywiki', 'mediawiki', 'go', 'gherkin'].concat(hljs.listLanguages())
 var supportCharts = ['sequence', 'flow', 'graphviz', 'mermaid', 'abc']
 var supportHeaders = [
   {


### PR DESCRIPTION
Right now we support code highlighting for rust, but it doesn't appear
in autocomplete of codemirror, because codemirror is not aware of it.

This patch lets highlightjs simply tell codemirror, what it supports and
adds this to the autocomplete list.