### PR TITLE
Pass HSTS max-age as seconds

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,7 +83,7 @@ app.use(compression())
 // use hsts to tell https users stick to this
 if (config.hsts.enable) {
   app.use(helmet.hsts({
-    maxAge: config.hsts.maxAgeSeconds * 1000,
+    maxAge: config.hsts.maxAgeSeconds,
     includeSubdomains: config.hsts.includeSubdomains,
     preload: config.hsts.preload
   }))


### PR DESCRIPTION
CodiMD 1.2.1 passes the HSTS `max-age` to Helmet as milliseconds. Not sure if this was required at some point, but it doesn't seem to be now: https://helmetjs.github.io/docs/hsts/