### PR TITLE
Remove Gitter from codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ CodiMD
 
 [![Standard - JavaScript Style Guide][standardjs-image]][standardjs-url]
 
-[![Join the chat at https://gitter.im/hackmdio/hackmd][gitter-image]][gitter-url]
 [![#CodiMD on matrix.org][matrix.org-image]][matrix.org-url]
 [![build status][travis-image]][travis-url]
 [![version][github-version-badge]][github-release-page]
@@ -364,8 +363,6 @@ See more at [http://operational-transformation.github.io/](http://operational-tr
 
 **License under AGPL.**
 
-[gitter-image]: https://badges.gitter.im/Join%20Chat.svg
-[gitter-url]: https://gitter.im/hackmdio/hackmd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [matrix.org-image]: https://img.shields.io/badge/Matrix.org-%23CodiMD@matrix.org-green.svg
 [matrix.org-url]: https://riot.im/app/#/room/#codimd:matrix.org
 [travis-image]: https://travis-ci.org/hackmdio/codimd.svg?branch=master

--- a/locales/en.json
+++ b/locales/en.json
@@ -111,5 +111,6 @@
 	"Do you really want to delete your user account?": "Do you really want to delete your user account?",
 	"This will delete your account, all notes that are owned by you and remove all references to your account from other notes.": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes.",
 	"Delete user": "Delete user",
-	"Export user data": "Export user data"
+	"Export user data": "Export user data",
+	"Help us translating on %s": "Help us translating on %s"
 }

--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -8,7 +8,7 @@ This means that you can write notes with other people on your **desktop**, **tab
 You can sign-in via multiple auth providers like **Facebook**, **Twitter**, **GitHub** and many more on the [_homepage_](/).
 
 If you experience any _issues_, feel free to report it on [**GitHub**](https://github.com/hackmdio/codimd/issues).
-Or meet us on [**Matrix.org**](https://riot.im/app/#/room/#codimd:matrix.org) or [**Gitter**](https://gitter.im/hackmdio/hackmd) for dev-talk and interactive help.
+Or meet us on [**Matrix.org**](https://riot.im/app/#/room/#codimd:matrix.org) for dev-talk and interactive help.
 **Thank you very much!**
 
 Workspace

--- a/public/views/shared/help-modal.ejs
+++ b/public/views/shared/help-modal.ejs
@@ -19,7 +19,7 @@
                                 <br>
                                 <a href="https://riot.im/app/#/room/#codimd:matrix.org" target="_blank"><i class="fa fa-hashtag fa-fw"></i> <%= __('Meet us on %s', 'Matrix') %></a>
                                 <br>
-                                <a href="https://gitter.im/hackmdio/hackmd" target="_blank"><i class="fa fa-comments fa-fw"></i> <%= __('Meet us on %s', 'Gitter') %></a>
+                                <a href="https://translate.codimd.org" target="_blank"><i class="fa fa-language fa-fw"></i> <%= __('Help us translating on %s', 'POEditor') %></a>
                             </div>
                         </div>
                         <div class="panel panel-default">


### PR DESCRIPTION
We no longer use Gitter for development talk and similar. So we might
want to remove it?

This patch removes Gitter from README, help page and features page. And
replaces it in the help modal with POEditor, our translation platform.