### PR TITLE
Add download action to published notes

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -468,6 +468,8 @@ function publishNoteActions (req, res, next) {
   findNote(req, res, function (note) {
     var action = req.params.action
     switch (action) {
+      case 'download':
+        actionDownload(req, res, note)
       case 'edit':
         res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
         break

--- a/lib/response.js
+++ b/lib/response.js
@@ -470,6 +470,7 @@ function publishNoteActions (req, res, next) {
     switch (action) {
       case 'download':
         actionDownload(req, res, note)
+        break
       case 'edit':
         res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
         break


### PR DESCRIPTION
Right now, you can't perform the `/download` action on a published note.

Currently, with a normal note, `/download` works:

```
https://hackmd.io/B58Juygfrj4rg8AgdA/download    // ✔️ 
```

But, with the published, `download` isnt an allowed action:
```
https://hackmd.io/s/dtG9j/download         // ⛔️ 
```

This PR makes it so `download` works on published notes:
```
https://hackmd.io/s/dtG9j/download         //  ✔️
```

I think `download` should be an allowed action on published notes - published notes are read-only and downloading is a read-only operation - and it allows for a API-ish endpoint for easily downloading published notes.

🍕 

Signed-off-by: Alex Garcia <alexsebastian.garcia@gmail.com>