### PR TITLE
Fix emoji regex

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1147,7 +1147,7 @@ const pdfPlugin = new Plugin(
 
 const emojijsPlugin = new Plugin(
     // regexp to match emoji shortcodes :something:
-    /:([\d\D]*):/,
+    /:([^\s:]+):/,
 
     (match, utils) => {
       const emoji = match[1] ? match[1].toLowerCase() : undefined


### PR DESCRIPTION
The old regex, adapted from the other plugins, was a bit too open for
matching. This leads to matching something like: `This is a sentence:
[And something with a: in it.]()` which doesn't become a link anymore.
Because the match is: ` [And something with a`.

This patch provides a fix for the regex to only match non-space string
within the `:`'s.

References:
- Introducing commit:
https://github.com/hackmdio/codimd/commit/2063eb8bdf9c0537e9fcfadd7f587658c72bd281
- Inspirational source of the original RegEx:
https://github.com/hackmdio/codimd/blob/2063eb8bdf9c0537e9fcfadd7f587658c72bd281/public/js/extra.js#L1095