### PR TITLE
Again: Replace emoji-plugin regex

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1147,15 +1147,14 @@ const pdfPlugin = new Plugin(
 
 const emojijsPlugin = new Plugin(
     // regexp to match emoji shortcodes :something:
-    /:([^\s:]+):/,
+    // We generate an universal regex that guaranteed only contains the
+    // emojies we have available. This should prevent all false-positives
+    new RegExp(':(' + window.emojify.emojiNames.map((item) => { return RegExp.escape(item) }).join('|') + '):', 'i'),
 
     (match, utils) => {
-      const emoji = match[1] ? match[1].toLowerCase() : undefined
-      if (window.emojify.emojiNames.includes(emoji)) {
-        const div = $(`<img class="emoji" src="${serverurl}/build/emojify.js/dist/images/basic/${emoji}.png"></img>`)
-        return div[0].outerHTML
-      }
-      return match[0]
+      const emoji = match[1].toLowerCase()
+      const div = $(`<img class="emoji" src="${serverurl}/build/emojify.js/dist/images/basic/${emoji}.png"></img>`)
+      return div[0].outerHTML
     }
 )
 


### PR DESCRIPTION
The Regex introduced in the last commit, was already working quite
good. But still resulted in false positives for all URL that contained a
second `:`.

To fix this once and for all, we craft a simple, but long regex based on
all emoji names and use this to match them.

We could probably optimize it, but that should also be something the
regex engine itself can and should do.

Reference: 7e45533c75a3697c916e52e5f4ddff42a38bd3d5