### PR TITLE
Fix menu when gitlab is enabled

### DIFF
--- a/app.js
+++ b/app.js
@@ -198,6 +198,7 @@ app.locals.authProviders = {
   email: config.isEmailEnable,
   allowEmailRegister: config.allowEmailRegister
 }
+app.locals.enableGitlabSnippets = (!config.gitlab.scope || config.gitlab.scope === 'api')
 
 app.use(require('./lib/web/baseRouter'))
 app.use(require('./lib/web/statusRouter'))

--- a/app.js
+++ b/app.js
@@ -198,7 +198,11 @@ app.locals.authProviders = {
   email: config.isEmailEnable,
   allowEmailRegister: config.allowEmailRegister
 }
-app.locals.enableGitlabSnippets = (!config.gitlab.scope || config.gitlab.scope === 'api')
+
+// Export/Import menu items
+app.locals.enableDropBoxSave = config.isDropboxEnable
+app.locals.enableGitHubGist = config.isGitHubEnable
+app.locals.enableGitlabSnippets = config.isGitlabSnippetsEnable
 
 app.use(require('./lib/web/baseRouter'))
 app.use(require('./lib/web/statusRouter'))

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -110,6 +110,8 @@ if (config.gitlab && config.gitlab.version !== 'v4' && config.gitlab.version !==
   logger.warn('config.js contains wrong version (' + config.gitlab.version + ') for gitlab api; it should be \'v3\' or \'v4\'. Defaulting to v4')
   config.gitlab.version = 'v4'
 }
+// If gitlab scope is api, enable snippets Export/import
+config.isGitlabSnippetsEnable = (!config.gitlab.scope || config.gitlab.scope === 'api')
 
 // Only update i18n files in development setups
 config.updateI18nFiles = (env === Environment.development)

--- a/public/views/codimd/header.ejs
+++ b/public/views/codimd/header.ejs
@@ -32,12 +32,12 @@
                 </li>
                 <li role="presentation"><a role="menuitem" class="ui-extra-slide" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-tv fa-fw"></i> <%= __('Slide Mode') %></a>
                 </li>
-                <% if((typeof github !== 'undefined' && github) || (typeof dropbox !== 'undefined' && dropbox) || enableGitlabSnippets) { %>
+                <% if(enableGitHubGist || enableDropBoxSave || enableGitlabSnippets) { %>
                 <li class="divider"></li>
                 <li class="dropdown-header"><%= __('Export') %></li>
                 <li role="presentation"><a role="menuitem" class="ui-save-dropbox" tabindex="-1" href="#" target="_self"><i class="fa fa-dropbox fa-fw"></i> Dropbox</a>
                 </li>
-                <% if(typeof github !== 'undefined' && github) { %>
+                <% if(enableGitHubGist) { %>
                 <li role="presentation"><a role="menuitem" class="ui-save-gist" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-github fa-fw"></i> Gist</a>
                 </li>
                 <% } %>
@@ -134,12 +134,12 @@
                     </li>
                     <li role="presentation"><a role="menuitem" class="ui-extra-slide" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-tv fa-fw"></i> <%= __('Slide Mode') %></a>
                     </li>
-                    <% if((typeof github !== 'undefined' && github) || (typeof dropbox !== 'undefined' && dropbox) || enableGitlabSnippets ) { %>
+                    <% if(enableGitHubGist || enableDropBoxSave || enableGitlabSnippets) { %>
                     <li class="divider"></li>
                     <li class="dropdown-header"><%= __('Export') %></li>
                     <li role="presentation"><a role="menuitem" class="ui-save-dropbox" tabindex="-1" href="#" target="_self"><i class="fa fa-dropbox fa-fw"></i> Dropbox</a>
                     </li>
-                    <% if(typeof github !== 'undefined' && github) { %>
+                    <% if(enableGitHubGist) { %>
                     <li role="presentation"><a role="menuitem" class="ui-save-gist" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-github fa-fw"></i> Gist</a>
                     </li>
                     <% } %>

--- a/public/views/codimd/header.ejs
+++ b/public/views/codimd/header.ejs
@@ -32,7 +32,7 @@
                 </li>
                 <li role="presentation"><a role="menuitem" class="ui-extra-slide" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-tv fa-fw"></i> <%= __('Slide Mode') %></a>
                 </li>
-                <% if((typeof github !== 'undefined' && github) || (typeof dropbox !== 'undefined' && dropbox) || (typeof gitlab !== 'undefined' && gitlab && (!gitlab.scope || gitlab.scope === 'api'))) { %>
+                <% if((typeof github !== 'undefined' && github) || (typeof dropbox !== 'undefined' && dropbox) || enableGitlabSnippets) { %>
                 <li class="divider"></li>
                 <li class="dropdown-header"><%= __('Export') %></li>
                 <li role="presentation"><a role="menuitem" class="ui-save-dropbox" tabindex="-1" href="#" target="_self"><i class="fa fa-dropbox fa-fw"></i> Dropbox</a>
@@ -41,7 +41,7 @@
                 <li role="presentation"><a role="menuitem" class="ui-save-gist" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-github fa-fw"></i> Gist</a>
                 </li>
                 <% } %>
-                <% if(typeof gitlab !== 'undefined' && gitlab && (!gitlab.scope || gitlab.scope === 'api')) { %>
+                <% if(enableGitlabSnippets) { %>
                 <li role="presentation"><a role="menuitem" class="ui-save-snippet" href="#"><i class="fa fa-gitlab fa-fw"></i> Snippet</a>
                 </li>
                 <% } %>
@@ -52,7 +52,7 @@
                 </li>
                 <li role="presentation"><a role="menuitem" class="ui-import-gist" href="#" data-toggle="modal" data-target="#gistImportModal"><i class="fa fa-github fa-fw"></i> Gist</a>
                 </li>
-                <% if(typeof gitlab !== 'undefined' && gitlab && (!gitlab.scope || gitlab.scope === 'api')) { %>
+                <% if(enableGitlabSnippets) { %>
                 <li role="presentation"><a role="menuitem" class="ui-import-snippet" href="#"><i class="fa fa-gitlab fa-fw"></i> Snippet</a>
                 </li>
                 <% } %>
@@ -134,7 +134,7 @@
                     </li>
                     <li role="presentation"><a role="menuitem" class="ui-extra-slide" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-tv fa-fw"></i> <%= __('Slide Mode') %></a>
                     </li>
-                    <% if((typeof github !== 'undefined' && github) || (typeof dropbox !== 'undefined' && dropbox) || (typeof gitlab !== 'undefined' && gitlab && (!gitlab.scope || gitlab.scope === 'api'))) { %>
+                    <% if((typeof github !== 'undefined' && github) || (typeof dropbox !== 'undefined' && dropbox) || enableGitlabSnippets ) { %>
                     <li class="divider"></li>
                     <li class="dropdown-header"><%= __('Export') %></li>
                     <li role="presentation"><a role="menuitem" class="ui-save-dropbox" tabindex="-1" href="#" target="_self"><i class="fa fa-dropbox fa-fw"></i> Dropbox</a>
@@ -143,7 +143,7 @@
                     <li role="presentation"><a role="menuitem" class="ui-save-gist" tabindex="-1" href="#" target="_blank" rel="noopener"><i class="fa fa-github fa-fw"></i> Gist</a>
                     </li>
                     <% } %>
-                    <% if(typeof gitlab !== 'undefined' && gitlab && (!gitlab.scope || gitlab.scope === 'api')) { %>
+                    <% if(enableGitlabSnippets) { %>
                     <li role="presentation"><a role="menuitem" class="ui-save-snippet" href="#"><i class="fa fa-gitlab fa-fw"></i> Snippet</a>
                     </li>
                     <% } %>
@@ -154,7 +154,7 @@
                     </li>
                     <li role="presentation"><a role="menuitem" class="ui-import-gist" href="#" data-toggle="modal" data-target="#gistImportModal"><i class="fa fa-github fa-fw"></i> Gist</a>
                     </li>
-                    <% if(typeof gitlab !== 'undefined' && gitlab && (!gitlab.scope || gitlab.scope === 'api')) { %>
+                    <% if(enableGitlabSnippets) { %>
                     <li role="presentation"><a role="menuitem" class="ui-import-snippet" href="#"><i class="fa fa-gitlab fa-fw"></i> Snippet</a>
                     </li>
                     <% } %>


### PR DESCRIPTION
When gitlab is enabled with scope API, the menu Export/Import Snippets is not displayed.
This is because gitlab var stay indefined in public/views/codimd/header.ejs.

The fix here is to add a var `enableGitlabSnippets` and then use it in header.ejs.