### PR TITLE
Fix ToC breaking documents with empty h* elements

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -846,11 +846,13 @@ const linkifyAnchors = (level, containingElement) => {
     let header = headers[i]
     if (header.getElementsByClassName('anchor').length === 0) {
       if (typeof header.id === 'undefined' || header.id === '') {
-                // to escape characters not allow in css and humanize
+        // to escape characters not allow in css and humanize
         const id = slugifyWithUTF8(getHeaderContent(header))
         header.id = id
       }
-      header.insertBefore(anchorForId(header.id), header.firstChild)
+      if (!(typeof header.id === 'undefined' || header.id === '')) {
+        header.insertBefore(anchorForId(header.id), header.firstChild)
+      }
     }
   }
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2786,6 +2786,7 @@ function updateViewInner () {
   renderTOC(ui.area.markdown)
   generateToc('ui-toc')
   generateToc('ui-toc-affix')
+  autoLinkify(ui.area.markdown)
   generateScrollspy()
   updateScrollspy()
   smoothHashScroll()

--- a/public/vendor/md-toc.js
+++ b/public/vendor/md-toc.js
@@ -44,7 +44,7 @@
     }
   }
 
-  Toc.prototype._createTocContent = function recursiveToc(level = 0, titleElements = [], titleNames = [], ulClass = undefined) {
+  Toc.prototype._createTocContent = function recursiveToc(level = 0, titleElements = [], titleNames = [], ulClass = undefined, index = 0) {
     // Inititalize our elements from the toc object
     // which is only available on level 0
     if (level === 0) {
@@ -74,8 +74,8 @@
         var elementText = (typeof this.process === 'function' ? this.process(element) : element.innerHTML).replace(/<(?:.|\n)*?>/gm, '')
         var id = element.getAttribute('id')
         if (!id) {
-          element.setAttribute('id', 'tip' + i)
-          id = '#tip' + i
+          element.setAttribute('id', 'tip' + ++index)
+          id = '#tip' + index
         } else {
           id = '#' + id
         }
@@ -97,7 +97,7 @@
         // This element is for the lower lever, we have to re-add it before we send the list down there.
         titleElements.unshift(element)
         // Let's call ourself and get to the next level
-        content += recursiveToc(level + 1, titleElements, titleNames, ulClass)
+        content += recursiveToc(level + 1, titleElements, titleNames, ulClass, index)
       } else {
         // When we end up here, met a higher level element
         // This is not our business so back into the list with the element and let's end this loop


### PR DESCRIPTION
Right now, the ToC has an undefined variable i that was an index in the 
original ToC code. Since the major rewrite in 
4fe062085324c50f2cfa062258559cf31858ef5f it's a recursive function 
without this index. The variable `i` was wrongly copied into its current 
place from the old code.

This patch replaces the variable `i` with the index of the header 
element. Fix the undefined variable problem.

Fixes #1042 