### PR TITLE
Fix wrong reading from commit

### DIFF
--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -33,7 +33,7 @@ exports.getGitCommit = function getGitCommit (repodir) {
     reference = reference.substr(5).replace('\n', '')
     reference = fs.readFileSync(path.resolve(repodir + '/.git', reference), 'utf8')
   }
-  reference = reference.substr(5).replace('\n', '')
+  reference = reference.replace('\n', '')
   return reference
 }
 


### PR DESCRIPTION
Right now we use a substr after reading the commit. That's definitely 
wrong and leads to wrong commit hashes since the first 5 chars are 
missing.

This patch removes the substr usage here and this way fixes the 
generated links.