### PR TITLE
Disallow creation of robots.txt in freeurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ There are some config settings you need to change in the files below.
 | `CMD_ALLOW_ANONYMOUS` | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | `CMD_ALLOW_ANONYMOUS_EDITS` | `true` or `false` | if `allowAnonymous` is `true`, allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`) |
 | `CMD_ALLOW_FREEURL` | `true` or `false` | set to allow new note creation by accessing a nonexistent note URL |
+| `CMD_FORBIDDEN_NODE_IDS` | `'robots.txt'` | disallow creation of notes, even if `CMD_ALLOW_FREEURL` is `true` |
 | `CMD_DEFAULT_PERMISSION` | `freely`, `editable`, `limited`, `locked` or `private` | set notes default permission (only applied on signed users) |
 | `CMD_DB_URL` | `mysql://localhost:3306/database` | set the database URL |
 | `CMD_SESSION_SECRET` | no example | Secret used to sign the session cookie. If non is set, one will randomly generated on startup |
@@ -284,6 +285,7 @@ There are some config settings you need to change in the files below.
 | `allowAnonymous` | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | `allowAnonymousEdits` | `true` or `false` | if `allowAnonymous` is `true`: allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`) |
 | `allowFreeURL` | `true` or `false` | set to allow new note creation by accessing a nonexistent note URL |
+| `forbiddenNoteIDs` | `['robots.txt']` | disallow creation of notes, even if `allowFreeUrl` is `true` |
 | `defaultPermission` | `freely`, `editable`, `limited`, `locked`, `protected` or `private` | set notes default permission (only applied on signed users) |
 | `dbURL` | `mysql://localhost:3306/database` | set the db URL; if set, then db config (below) won't be applied |
 | `db` | `{ "dialect": "sqlite", "storage": "./db.codimd.sqlite" }` | set the db configs, [see more here](http://sequelize.readthedocs.org/en/latest/api/sequelize/) |

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -31,6 +31,7 @@ module.exports = {
   allowAnonymous: true,
   allowAnonymousEdits: false,
   allowFreeURL: false,
+  forbiddenNoteIDs: ['robots.txt', 'favicon.ico', 'api'],
   defaultPermission: 'editable',
   dbURL: '',
   db: {},

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -27,6 +27,7 @@ module.exports = {
   allowAnonymous: toBooleanConfig(process.env.CMD_ALLOW_ANONYMOUS),
   allowAnonymousEdits: toBooleanConfig(process.env.CMD_ALLOW_ANONYMOUS_EDITS),
   allowFreeURL: toBooleanConfig(process.env.CMD_ALLOW_FREEURL),
+  forbiddenNoteIDs: toArrayConfig(process.env.CMD_FORBIDDEN_NOTE_IDS),
   defaultPermission: process.env.CMD_DEFAULT_PERMISSION,
   dbURL: process.env.CMD_DB_URL,
   sessionSecret: process.env.CMD_SESSION_SECRET,

--- a/lib/response.js
+++ b/lib/response.js
@@ -157,7 +157,7 @@ function findNote (req, res, callback, include) {
       include: include || null
     }).then(function (note) {
       if (!note) {
-        if (config.allowFreeURL && noteId) {
+        if (config.allowFreeURL && noteId && !config.forbiddenNoteIDs.includes(noteId)) {
           req.alias = noteId
           return newNote(req, res)
         } else {


### PR DESCRIPTION
Add a configuration setting to "hard"-disable creation of notes as set by the configuration value `CMD_FORBIDDEN_NOTE_IDS`. This defaults to `['robots.txt', 'favicon.ico']`, because these files are often accidentally created by bots and browsers.

As of now, it does not seem that a custom `robots.txt` file is needed. Looking from the other code in the source tree the general convention seems to be using `x-robots-tag` headers. So we can just return a `404 Not Found` error on `/robots.txt`.

However, we don't want to break an installation that already has these notes created (purposefully). So instead of blocking requests to `/robots.txt`, we will block any request to create it.

This PR fixes #1052.