### PR TITLE
InternalOAuthError is not part of passport, but of passport-oauth2 #1056

### DIFF
--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -2,13 +2,13 @@
 
 const Router = require('express').Router
 const passport = require('passport')
-const OAuth2Strategy = require('passport-oauth2').Strategy
+const { Strategy, InternalOAuthError } = require('passport-oauth2')
 const config = require('../../../config')
 const {setReturnToFromReferer, passportGeneralCallback} = require('../utils')
 
 let oauth2Auth = module.exports = Router()
 
-class OAuth2CustomStrategy extends OAuth2Strategy {
+class OAuth2CustomStrategy extends Strategy {
   constructor (options, verify) {
     options.customHeaders = options.customHeaders || {}
     super(options, verify)
@@ -22,7 +22,7 @@ class OAuth2CustomStrategy extends OAuth2Strategy {
       var json
 
       if (err) {
-        return done(new passport.InternalOAuthError('Failed to fetch user profile', err))
+        return done(new InternalOAuthError('Failed to fetch user profile', err))
       }
 
       try {
@@ -67,7 +67,7 @@ OAuth2CustomStrategy.prototype.userProfile = function (accessToken, done) {
     var json
 
     if (err) {
-      return done(new passport.InternalOAuthError('Failed to fetch user profile', err))
+      return done(new InternalOAuthError('Failed to fetch user profile', err))
     }
 
     try {


### PR DESCRIPTION
In case anything goes wrong while fetching the profile, the login process would fail with a `502` because the InternalOAuthError does not exist within passport.

This fixes it, as demonstrated in #1056. It is not ideal, yet (the error itself is nowhere to be found), but at least it does not crash the server any more.