### PR TITLE
Fix streaming for winston

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ if (config.useSSL) {
 
 // logger
 app.use(morgan('combined', {
-  'stream': logger
+  'stream': logger.stream
 }))
 
 // socket io

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,7 @@
 'use strict'
 const {createLogger, format, transports} = require('winston')
 
-module.exports = createLogger({
+const logger = createLogger({
   level: 'debug',
   format: format.combine(
     format.uncolorize(),
@@ -17,3 +17,11 @@ module.exports = createLogger({
   ],
   exitOnError: false
 })
+
+logger.stream = {
+  write: function (message, encoding) {
+    logger.info(message)
+  }
+}
+
+module.exports = logger


### PR DESCRIPTION
During the upgrade of winston in 
c3584770f24205d84b9399abd9535cb27dc7b00c a the class extension for 
streaming was removed.

This caused silent crashes. Somehow winston simply called 
`process.exit(1)` whenever `logger.write()` was called. This is really 
bad and only easy to debug because of the testing right after upgrading.

However, reimplementing the stream interface as it was, didn't work, due 
to the fact that `logger.write()` is already implemented and causes the 
mentioned problem. So we extent the object with an `stream` object that 
implements `write()` for streams and pass that to morgan.

So this patch fixes unexpected exiting for streaming towards our logging 
module.

References:
https://www.digitalocean.com/community/tutorials/how-to-use-winston-to-log-node-js-applications
https://github.com/hackmdio/codimd/commit/c3584770f24205d84b9399abd9535cb27dc7b00c
https://stackoverflow.com/a/28824464