### PR TITLE
Fixing links on index page

### DIFF
--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -65,19 +65,19 @@
                     </span>
                     <div class="lead row" style="width: 90%; margin: 0 auto;">
                         <div class="col-md-4 inner">
-                            <a href="<%- serverURL %>/features#share-notes">
+                            <a href="<%- serverURL %>/features#Share-Notes">
                                 <i class="fa fa-bolt fa-3x"></i>
                                 <h4><%= __('Collaborate with URL') %></h4>
                             </a>
                         </div>
                         <div class="col-md-4 inner">
-                            <a href="<%- serverURL %>/features#mathjax">
+                            <a href="<%- serverURL %>/features#MathJax">
                                 <i class="fa fa-bar-chart fa-3x"></i>
                                 <h4><%= __('Support charts and MathJax') %></h4>
                             </a>
                         </div>
                         <div class="col-md-4 inner">
-                            <a href="<%- serverURL %>/features#slide-mode">
+                            <a href="<%- serverURL %>/features#Slide-Modee">
                                 <i class="fa fa-tv fa-3x"></i>
                                 <h4><%= __('Support slide mode') %></h4>
                             </a>


### PR DESCRIPTION
Seems like ids in Firefox are case sensitive. So linking in the current 
way fails.

This patch fixes the links by using the exact matching version of the 
titles on the features page.