### PR TITLE
Add hints about how to be informed about updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Just to more confusion: We are still friends with HackMD :heart:
 7. Run `node_modules/.bin/sequelize db:migrate`, this step will migrate your db to the latest schema
 8. Run the server as you like (node, forever, pm2)
 
+To stay up to date with your installation it's recommended to join our [Matrix channel][matrix.org-url] or subscribe to the [release feed][github-release-feed].
+
 ## Heroku Deployment
 
 You can quickly setup a sample Heroku CodiMD application by clicking the button below.
@@ -139,6 +141,7 @@ If you are upgrading CodiMD from an older version, follow these steps:
 6. Run `node_modules/.bin/sequelize db:migrate`, this step will migrate your db to the latest schema
 7. Start your whole new server!
 
+To stay up to date with your installation it's recommended to join our [Matrix channel][matrix.org-url] or subscribe to the [release feed][github-release-feed].
 
 * **migrate-to-1.1.0**
 
@@ -373,5 +376,6 @@ See more at [http://operational-transformation.github.io/](http://operational-tr
 [travis-url]: https://travis-ci.org/hackmdio/codimd
 [github-version-badge]: https://img.shields.io/github/release/hackmdio/codimd.svg
 [github-release-page]: https://github.com/hackmdio/codimd/releases
+[github-release-feed]: https://github.com/hackmdio/codimd/releases.atom
 [poeditor-image]: https://img.shields.io/badge/POEditor-translate-blue.svg
 [poeditor-url]: https://poeditor.com/join/project/1OpGjF2Jir


### PR DESCRIPTION
Keeping people in the loop about new version of CodiMD is not easy. When
people don't keep an eye on GitHub it's easy to miss new versions.

To help people keeping their software up to date, this patch adds hints
to check out our community channel or simply the GitHub Atom feed
generated for based on the release page to get informed about new
versions.