### PR TITLE
After removing ws, node version 10 should work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ jobs:
       before_install:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
         - export PATH="$HOME/.yarn/bin:$PATH"
+    - env: task=npm-test
+      node_js:
+        - 10
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
+        - export PATH="$HOME/.yarn/bin:$PATH"
     - env: task=ShellCheck
       script:
         - shellcheck bin/heroku bin/setup

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "xss": "^1.0.3"
   },
   "engines": {
-    "node": ">=6.x <10.x"
+    "node": ">=6.x"
   },
   "bugs": "https://github.com/hackmdio/codimd/issues",
   "keywords": [


### PR DESCRIPTION
In my local environment I switched to Fedora 29. Fedora 29 comes with
NodeJS version 10.

As far as I can say, it works, so let's try to remove the restriction to
"<10.x"

**Edit:** We should also consider to provide 1.4.0 (yes, explicitly not 1.3.0) using Node version 10 in the container images.