### PR TITLE
Fix wrong maxAgeSeconds multiplication

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,7 +83,7 @@ app.use(compression())
 // use hsts to tell https users stick to this
 if (config.hsts.enable) {
   app.use(helmet.hsts({
-    maxAge: config.hsts.maxAgeSeconds * 1000,
+    maxAge: config.hsts.maxAgeSeconds,
     includeSubdomains: config.hsts.includeSubdomains,
     preload: config.hsts.preload
   }))

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -13,7 +13,7 @@ module.exports = {
   useSSL: false,
   hsts: {
     enable: true,
-    maxAgeSeconds: 31536000,
+    maxAgeSeconds: 60 * 60 * 24 * 365,
     includeSubdomains: true,
     preload: true
   },


### PR DESCRIPTION
It seems like the inital work on the hsts module expected milliseconds.
This has either changed or was never true. Either way, it caused that
the current defaults resulted in theory in a 1000 year HSTS policy.
Luckily helmet was smart enough to not go higher than 1 year.

Anyway, this patch fixes the multiplication of the configured size with
1000 by removing this multiplication.

Also to simplify the reading of the defaults, we split them into their
components, 60 times 60 seconds so we get one hour. 24 of those hours so
we get a day and finally 365 days to get our original wanted default of
one year.

Reference:
https://github.com/hackmdio/CodiMD/commit/d69d65ea7434eee85db4b905f0852f4d8fa7ecce

Fixes #1015 