### PR TITLE
Switch scrypt library to a successor

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -1,7 +1,7 @@
 'use strict'
 // external modules
 var Sequelize = require('sequelize')
-var scrypt = require('scrypt')
+var scrypt = require('@mlink/scrypt')
 
 // core
 var logger = require('../logger')

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "readline-sync": "^1.4.7",
     "request": "^2.88.0",
     "reveal.js": "~3.7.0",
-    "scrypt": "^6.0.3",
+    "@mlink/scrypt": "^6.1.2",
     "select2": "^3.5.2-browserify",
     "sequelize": "^3.28.0",
     "sequelize-cli": "^2.5.1",


### PR DESCRIPTION
Since our previous scrypt library is unmaintained since 3 years, it's
time to look for an alternative.

A refactoring towards another password algorithm was worked on and this
is probably still the way to go. But for now the successor of our
previous library should already be enough.

https://www.npmjs.com/package/scrypt (old library)
https://github.com/ml1nk/node-scrypt (new library)