### PR TITLE
Fix some linting warnings in `./lib/config`

### DIFF
--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {toBooleanConfig, toArrayConfig, toIntegerConfig} = require('./utils')
+const { toBooleanConfig, toArrayConfig, toIntegerConfig } = require('./utils')
 
 module.exports = {
   sourceURL: process.env.CMD_SOURCE_URL,

--- a/lib/config/hackmdEnvironment.js
+++ b/lib/config/hackmdEnvironment.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {toBooleanConfig, toArrayConfig, toIntegerConfig} = require('./utils')
+const { toBooleanConfig, toArrayConfig, toIntegerConfig } = require('./utils')
 
 module.exports = {
   domain: process.env.HMD_DOMAIN,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -4,11 +4,11 @@
 const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
-const {merge} = require('lodash')
+const { merge } = require('lodash')
 const deepFreeze = require('deep-freeze')
-const {Environment, Permission} = require('./enum')
+const { Environment, Permission } = require('./enum')
 const logger = require('../logger')
-const {getGitCommit, getGitHubURL} = require('./utils')
+const { getGitCommit, getGitHubURL } = require('./utils')
 
 const appRootPath = path.resolve(__dirname, '../../')
 const env = process.env.NODE_ENV || Environment.development
@@ -17,7 +17,7 @@ const debugConfig = {
 }
 
 // Get version string from package.json
-const {version, repository} = require(path.join(appRootPath, 'package.json'))
+const { version, repository } = require(path.join(appRootPath, 'package.json'))
 
 const commitID = getGitCommit(appRootPath)
 const sourceURL = getGitHubURL(repository.url, commitID || version)
@@ -155,8 +155,8 @@ if (Object.keys(process.env).toString().indexOf('HMD_') !== -1) {
 if (config.sessionSecret === 'secret') {
   logger.warn('Session secret not set. Using random generated one. Please set `sessionSecret` in your config.js file. All users will be logged out.')
   config.sessionSecret = crypto.randomBytes(Math.ceil(config.sessionSecretLen / 2)) // generate crypto graphic random number
-        .toString('hex')                                                            // convert to hexadecimal format
-        .slice(0, config.sessionSecretLen)                                           // return required number of characters
+    .toString('hex') // convert to hexadecimal format
+    .slice(0, config.sessionSecretLen) // return required number of characters
 }
 
 // Validate upload upload providers

--- a/lib/config/oldEnvironment.js
+++ b/lib/config/oldEnvironment.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {toBooleanConfig} = require('./utils')
+const { toBooleanConfig } = require('./utils')
 
 module.exports = {
   debug: toBooleanConfig(process.env.DEBUG),


### PR DESCRIPTION
We decided to switch to eslint for linting. This caused some new linter
warnings.

This patch fixes them for `./lib/config`