### PR TITLE
Fix eslint warnings for database related libs

### DIFF
--- a/lib/migrations/20160112220142-note-add-lastchange.js
+++ b/lib/migrations/20160112220142-note-add-lastchange.js
@@ -18,8 +18,8 @@ module.exports = {
 
   down: function (queryInterface, Sequelize) {
     return queryInterface.removeColumn('Notes', 'lastchangeAt')
-    .then(function () {
-      return queryInterface.removeColumn('Notes', 'lastchangeuserId')
-    })
+      .then(function () {
+        return queryInterface.removeColumn('Notes', 'lastchangeuserId')
+      })
   }
 }

--- a/lib/migrations/20171009121200-longtext-for-mysql.js
+++ b/lib/migrations/20171009121200-longtext-for-mysql.js
@@ -1,16 +1,16 @@
 'use strict'
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    queryInterface.changeColumn('Notes', 'content', {type: Sequelize.TEXT('long')})
-    queryInterface.changeColumn('Revisions', 'patch', {type: Sequelize.TEXT('long')})
-    queryInterface.changeColumn('Revisions', 'content', {type: Sequelize.TEXT('long')})
-    queryInterface.changeColumn('Revisions', 'lastContent', {type: Sequelize.TEXT('long')})
+    queryInterface.changeColumn('Notes', 'content', { type: Sequelize.TEXT('long') })
+    queryInterface.changeColumn('Revisions', 'patch', { type: Sequelize.TEXT('long') })
+    queryInterface.changeColumn('Revisions', 'content', { type: Sequelize.TEXT('long') })
+    queryInterface.changeColumn('Revisions', 'lastContent', { type: Sequelize.TEXT('long') })
   },
 
   down: function (queryInterface, Sequelize) {
-    queryInterface.changeColumn('Notes', 'content', {type: Sequelize.TEXT})
-    queryInterface.changeColumn('Revisions', 'patch', {type: Sequelize.TEXT})
-    queryInterface.changeColumn('Revisions', 'content', {type: Sequelize.TEXT})
-    queryInterface.changeColumn('Revisions', 'lastContent', {type: Sequelize.TEXT})
+    queryInterface.changeColumn('Notes', 'content', { type: Sequelize.TEXT })
+    queryInterface.changeColumn('Revisions', 'patch', { type: Sequelize.TEXT })
+    queryInterface.changeColumn('Revisions', 'content', { type: Sequelize.TEXT })
+    queryInterface.changeColumn('Revisions', 'lastContent', { type: Sequelize.TEXT })
   }
 }

--- a/lib/migrations/20180209120907-longtext-of-authorship.js
+++ b/lib/migrations/20180209120907-longtext-of-authorship.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    queryInterface.changeColumn('Notes', 'authorship', {type: Sequelize.TEXT('long')})
-    queryInterface.changeColumn('Revisions', 'authorship', {type: Sequelize.TEXT('long')})
+    queryInterface.changeColumn('Notes', 'authorship', { type: Sequelize.TEXT('long') })
+    queryInterface.changeColumn('Revisions', 'authorship', { type: Sequelize.TEXT('long') })
   },
 
   down: function (queryInterface, Sequelize) {
-    queryInterface.changeColumn('Notes', 'authorship', {type: Sequelize.TEXT})
-    queryInterface.changeColumn('Revisions', 'authorship', {type: Sequelize.TEXT})
+    queryInterface.changeColumn('Notes', 'authorship', { type: Sequelize.TEXT })
+    queryInterface.changeColumn('Revisions', 'authorship', { type: Sequelize.TEXT })
   }
 }

--- a/lib/migrations/20180306150303-fix-enum.js
+++ b/lib/migrations/20180306150303-fix-enum.js
@@ -2,10 +2,10 @@
 
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    queryInterface.changeColumn('Notes', 'permission', {type: Sequelize.ENUM('freely', 'editable', 'limited', 'locked', 'protected', 'private')})
+    queryInterface.changeColumn('Notes', 'permission', { type: Sequelize.ENUM('freely', 'editable', 'limited', 'locked', 'protected', 'private') })
   },
 
   down: function (queryInterface, Sequelize) {
-    queryInterface.changeColumn('Notes', 'permission', {type: Sequelize.ENUM('freely', 'editable', 'locked', 'private')})
+    queryInterface.changeColumn('Notes', 'permission', { type: Sequelize.ENUM('freely', 'editable', 'locked', 'private') })
   }
 }

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -3,7 +3,7 @@
 var fs = require('fs')
 var path = require('path')
 var Sequelize = require('sequelize')
-const {cloneDeep} = require('lodash')
+const { cloneDeep } = require('lodash')
 
 // core
 var config = require('../config')
@@ -39,13 +39,13 @@ sequelize.processData = processData
 var db = {}
 
 fs.readdirSync(__dirname)
-    .filter(function (file) {
-      return (file.indexOf('.') !== 0) && (file !== 'index.js')
-    })
-    .forEach(function (file) {
-      var model = sequelize.import(path.join(__dirname, file))
-      db[model.name] = model
-    })
+  .filter(function (file) {
+    return (file.indexOf('.') !== 0) && (file !== 'index.js')
+  })
+  .forEach(function (file) {
+    var model = sequelize.import(path.join(__dirname, file))
+    db[model.name] = model
+  })
 
 Object.keys(db).forEach(function (modelName) {
   if ('associate' in db[modelName]) {

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -5,7 +5,7 @@ var scrypt = require('scrypt')
 
 // core
 var logger = require('../logger')
-var {generateAvatarURL} = require('../letter-avatars')
+var { generateAvatarURL } = require('../letter-avatars')
 
 module.exports = function (sequelize, DataTypes) {
   var User = sequelize.define('User', {


### PR DESCRIPTION
We introduced eslint as new linter to replace "`standard`". This causes
various warnings.

This patch fixes the warnings for `./lib/migrations` and `./lib/models`.