### PR TITLE
Fix typo in config.json.example

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -17,7 +17,7 @@
     },
     "production": {
         "domain": "localhost",
-        "loglevel": "info"
+        "loglevel": "info",
         "hsts": {
             "enable": true,
             "maxAgeSeconds": "31536000",


### PR DESCRIPTION
We recently added the new logging option. As it turns out, the new
option was not added correctly, which points out that our current json
linting is **not working**. It throws an error but doesn't break.

This patch fixes the typo in the example. It does not fix the CI part.