### PR TITLE
Remove node-uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "moment": "^2.17.1",
     "morgan": "^1.7.0",
     "mysql": "^2.12.0",
-    "node-uuid": "^1.4.7",
     "passport": "^0.4.0",
     "passport-dropbox-oauth2": "^1.1.0",
     "passport-facebook": "^2.1.1",


### PR DESCRIPTION
We currently install `uuid` and `node-uuid`. `node-uuid` is deprecated
in favor of `uuid`. It seems like we already switched a while ago, but
somehow missed to remove the dependency.

This patch does exactly that. It removes the dependency from
`package.json` and this way removes the warning during install about
`node-uuid` being deprecated.