### PR TITLE
Update doctoc to version 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "babel-runtime": "^6.26.0",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^1.0.0",
-    "doctoc": "^1.3.0",
+    "doctoc": "^1.4.0",
     "ejs-loader": "^0.3.1",
     "eslint": "^5.9.0",
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
When installing doctoc it throws some warnings about the markdown-to-ast
package that moved to an own namespace.

This patch updates to the version containing the new, namespaced,
package.

References:
https://github.com/thlorenz/doctoc/pull/151