### PR TITLE
Add config for toobusy middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ There are some config settings you need to change in the files below.
 | `CMD_DB_URL` | `mysql://localhost:3306/database` | set the database URL |
 | `CMD_SESSION_SECRET` | no example | Secret used to sign the session cookie. If non is set, one will randomly generated on startup |
 | `CMD_SESSION_LIFE` | `1209600000` | Session life time. (milliseconds) |
+| `CMD_TOOBUSY_LAG` | `70` | CPU time for one eventloop tick until node throttles connections. (milliseconds) |
 | `CMD_FACEBOOK_CLIENTID` | no example | Facebook API client id |
 | `CMD_FACEBOOK_CLIENTSECRET` | no example | Facebook API client secret |
 | `CMD_TWITTER_CONSUMERKEY` | no example | Twitter API consumer key |
@@ -304,6 +305,7 @@ There are some config settings you need to change in the files below.
 | `sessionName` | `connect.sid` | cookie session name |
 | `sessionSecret` | `secret` | cookie session secret |
 | `sessionLife` | `14 * 24 * 60 * 60 * 1000` | cookie session life |
+| `tooBusyLag` | `70` | CPU time for one eventloop tick until node throttles connections. (milliseconds) |
 | `staticCacheTime` | `1 * 24 * 60 * 60 * 1000` | static file cache time |
 | `heartbeatInterval` | `5000` | socket.io heartbeat interval |
 | `heartbeatTimeout` | `10000` | socket.io heartbeat timeout |

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -56,6 +56,8 @@ module.exports = {
   // socket.io
   heartbeatInterval: 5000,
   heartbeatTimeout: 10000,
+  // too busy timeout
+  tooBusyLag: 70,
   // document
   documentMaxLength: 100000,
   // image upload setting, available options are imgur/s3/filesystem/azure

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -33,6 +33,7 @@ module.exports = {
   dbURL: process.env.CMD_DB_URL,
   sessionSecret: process.env.CMD_SESSION_SECRET,
   sessionLife: toIntegerConfig(process.env.CMD_SESSION_LIFE),
+  tooBusyLag: toIntegerConfig(process.env.CMD_TOOBUSY_LAG),
   imageUploadType: process.env.CMD_IMAGE_UPLOAD_TYPE,
   imgur: {
     clientID: process.env.CMD_IMGUR_CLIENTID

--- a/lib/web/middleware/tooBusy.js
+++ b/lib/web/middleware/tooBusy.js
@@ -2,7 +2,11 @@
 
 const toobusy = require('toobusy-js')
 
+
 const response = require('../../response')
+const config = require('../../config')
+
+toobusy.maxLag(config.tooBusyLag)
 
 module.exports = function (req, res, next) {
   if (toobusy()) {


### PR DESCRIPTION
With very low CPU frequency or bad IO situation, as well as not-loaded
JS CodiMD happens to present unneeded "I'm busy"-messages to users.

This patch allows to configure the lag while keeping the libraries
defaults.

Fixes #1077 