### PR TITLE
Warn on missing serverURL

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -101,6 +101,10 @@ config.serverURL = (function getserverurl () {
   return url
 })()
 
+if (config.serverURL === '') {
+  logger.warn('Neither \'domain\' nor \'CMD_DOMAIN\' is configured. This can cause issues with various components.\nHint: Make sure \'protocolUseSSL\' and \'urlAddPort\' or \'CMD_PROTOCOL_USESSL\' and \'CMD_URL_ADDPORT\' are configured properly.')
+}
+
 config.Environment = Environment
 
 // auth method


### PR DESCRIPTION
We see some issues that are based on not properly configured
`config.serverURL`.

This patch adds a warning when `config.serverURL` is an empty value.
This should provide users direct feedback about how to improve their
configs.

Signed-off-by: Sheogorath <sheogorath@shivering-isles.com>