### PR TITLE
Fix: there is no "resolve" in "url.URL", just use "url.resolve"

### DIFF
--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -16,5 +16,6 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  callback(null, new url.URL(config.serverURL + '/uploads/', path.basename(imagePath)))
+  const imgURL = new url.URL(config.serverURL + '/uploads/', path.basename(imagePath))
+  callback(null, imgURL.toString())
 }

--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -16,5 +16,5 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  callback(null, url.URL.resolve(config.serverURL + '/uploads/', path.basename(imagePath)))
+  callback(null, url.resolve(config.serverURL + '/uploads/', path.basename(imagePath)))
 }

--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -16,5 +16,5 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  callback(null, url.resolve(config.serverURL + '/uploads/', path.basename(imagePath)))
+  callback(null, new url.URL(config.serverURL + '/uploads/', path.basename(imagePath)))
 }

--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -16,6 +16,5 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  const imgURL = new url.URL(config.serverURL + '/uploads/', path.basename(imagePath))
-  callback(null, imgURL.toString())
+  callback(null, url.resolve(config.serverURL + '/uploads/', path.basename(imagePath)))
 }


### PR DESCRIPTION
Current code cause a exception
```
app_1_90ac4102d220 | TypeError: url.URL.resolve is not a function
```
After some digging, there is no `url.URL.resolve(...)` but only `url.resolve(...)`.

Tested, and worked.