### PR TITLE
Fix CSP for speaker notes

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -71,7 +71,7 @@ function addInlineScriptExceptions (directives) {
   directives.scriptSrc.push(getCspNonce)
   // TODO: This is the SHA-256 hash of the inline script in build/reveal.js/plugins/notes/notes.html
   // Any more clean solution appreciated.
-  directives.scriptSrc.push('\'sha256-L0TsyAQLAc0koby5DCbFAwFfRs9ZxesA+4xg0QDSrdI=\'')
+  directives.scriptSrc.push('\'sha256-Lc+VnBdinzYTTAkFrIoUqdoA9EQFeS1AF9ybmF+LLfM=\'')
 }
 
 function getCspNonce (req, res) {


### PR DESCRIPTION
Looks like I was wrong in my previous commit to update revealjs.

The speaker notes broke again with the CSPs. So this patch updates the
hash and this way the speaker notes.

bcebf1e8d285184f8c905f00e0270621790e7b80

Signed-off-by: Sheogorath <sheogorath@shivering-isles.com>