### PR TITLE
Fix disqus CSP

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -23,7 +23,7 @@ var cdnDirectives = {
 }
 
 var disqusDirectives = {
-  scriptSrc: ['https://*.disqus.com', 'https://*.disquscdn.com'],
+  scriptSrc: ['https://disqus.com', 'https://*.disqus.com', 'https://*.disquscdn.com'],
   styleSrc: ['https://*.disquscdn.com'],
   fontSrc: ['https://*.disquscdn.com']
 }


### PR DESCRIPTION
Disqus loads it's embed config.js from its root domain
(https://disqus.com). Our CSPs only allow subdomains (e.g.:
https://codimd.disqus.com). This causes the disqus embedding to fail.

This patch should fix this problem by adding https://disqus.com to the
CSP setting. From a security perspective there is no real change. Since
still the same parties are involved.