### PR TITLE
Hide default ports from minio image upload urls

### DIFF
--- a/lib/web/imageRouter/minio.js
+++ b/lib/web/imageRouter/minio.js
@@ -40,7 +40,7 @@ exports.uploadImage = function (imagePath, callback) {
         callback(new Error(err), null)
         return
       }
-      let hidePort = (protocol === 'http' && config.minio.port === 80) || (protocol === 'https' && config.minio.port === 443)
+      let hidePort = [80, 443].includes(config.minio.port)
       let urlPort = hidePort ? '' : `:${config.minio.port}`
       callback(null, `${protocol}://${config.minio.endPoint}${urlPort}/${config.s3bucket}/${key}`)
     })

--- a/lib/web/imageRouter/minio.js
+++ b/lib/web/imageRouter/minio.js
@@ -40,7 +40,9 @@ exports.uploadImage = function (imagePath, callback) {
         callback(new Error(err), null)
         return
       }
-      callback(null, `${protocol}://${config.minio.endPoint}:${config.minio.port}/${config.s3bucket}/${key}`)
+      let hidePort = (protocol === 'http' && config.minio.port === 80) || (protocol === 'https' && config.minio.port === 443)
+      let urlPort = hidePort ? '' : `:${config.minio.port}`
+      callback(null, `${protocol}://${config.minio.endPoint}${urlPort}/${config.s3bucket}/${key}`)
     })
   })
 }


### PR DESCRIPTION
With the current state this behaviour is enabled by default and can be disabled by setting
```json
{
  "minio": {
    "hideDefaultPorts": false
  }
}
```

or `CMD_MINIO_HIDE_DEFAULT_PORTS=false`.

Fix #1094