### PR TITLE
Fix usage of new URL API

### DIFF
--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -1,5 +1,5 @@
 'use strict'
-const url = require('url')
+const URL = require('url').URL
 const path = require('path')
 
 const config = require('../../config')
@@ -16,5 +16,5 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  callback(null, url.URL.resolve(config.serverURL + '/uploads/', path.basename(imagePath)))
+  callback(null, (new URL(path.basename(imagePath), config.serverURL + '/uploads/')).href)
 }


### PR DESCRIPTION
Due to the deprecation of the old `url`-API provided by NodeJS we
replaced `url.resolve` with `url.URL.resolve`, which doesn't exist.

This patch fixes the local filesystem upload of CodiMD by using the new
API correctly. Creating an URL object and using its href.

Some more background:
https://nodejs.org/api/url.html#url_url_href
https://nodejs.org/api/url.html#url_url_resolve_from_to

Fixes https://github.com/hackmdio/codimd/issues/1102