### PR TITLE
Fix broken Gist embedding

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -8,7 +8,7 @@ var defaultDirectives = {
   scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net', 'https://query.yahooapis.com', '\'unsafe-eval\''],
   // ^ TODO: Remove unsafe-eval - webpack script-loader issues https://github.com/hackmdio/codimd/issues/594
   imgSrc: ['*'],
-  styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://assets-cdn.github.com'], // unsafe-inline is required for some libs, plus used in views
+  styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://github.githubassets.com'], // unsafe-inline is required for some libs, plus used in views
   fontSrc: ['\'self\'', 'data:', 'https://public.slidesharecdn.com'],
   objectSrc: ['*'], // Chrome PDF viewer treats PDFs as objects :/
   mediaSrc: ['*'],


### PR DESCRIPTION
Looks like GitHub changed their asset system and our CSP prevented them
from getting loaded.

This patch should fix the Gist embedding with enabled CSP by replacing
the old URL `https://assets-cdn.github.com` with the new
`https://github.githubassets.com`.