### PR TITLE
Remove blueimp-md5 dependency

### DIFF
--- a/lib/letter-avatars.js
+++ b/lib/letter-avatars.js
@@ -1,6 +1,6 @@
 'use strict'
 // external modules
-const md5 = require('blueimp-md5')
+const crypto = require('crypto')
 const randomcolor = require('randomcolor')
 const config = require('./config')
 
@@ -31,15 +31,19 @@ exports.generateAvatarURL = function (name, email = '', big = true) {
     email = '' + name + '@example.com'
   }
 
+  let hash = crypto.createHash('md5')
+  hash.update(email.toLowerCase())
+  let hexDigest = hash.digest('hex')
+
   if (email !== '' && config.allowGravatar) {
-    photo = 'https://www.gravatar.com/avatar/' + md5(email.toLowerCase())
+    photo = 'https://www.gravatar.com/avatar/' + hexDigest;
     if (big) {
       photo += '?s=400'
     } else {
       photo += '?s=96'
     }
   } else {
-    photo = config.serverURL + '/user/' + (name || email.substring(0, email.lastIndexOf('@')) || md5(email.toLowerCase())) + '/avatar.svg'
+    photo = config.serverURL + '/user/' + (name || email.substring(0, email.lastIndexOf('@')) || hexDigest) + '/avatar.svg'
   }
   return photo
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "license": "AGPL-3.0",
   "scripts": {
-    "test": "npm run-script eslint && npm run-script jsonlint",
+    "test": "npm run-script eslint && npm run-script jsonlint && mocha",
     "eslint": "node_modules/.bin/eslint lib public app.js",
     "jsonlint": "find . -not -path './node_modules/*' -type f -name '*.json' -o -type f -name '*.json.example' | while read json; do echo $json ; jq . $json; done",
     "standard": "echo 'standard is no longer being used, use `npm run eslint` instead!' && exit 1",
@@ -184,6 +184,7 @@
     "less": "^2.7.1",
     "less-loader": "^4.1.0",
     "mini-css-extract-plugin": "^0.4.1",
+    "mocha": "^5.2.0",
     "optimize-css-assets-webpack-plugin": "^5.0.0",
     "script-loader": "^0.7.2",
     "string-loader": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "aws-sdk": "^2.345.0",
     "azure-storage": "^2.7.0",
     "base64url": "^3.0.0",
-    "blueimp-md5": "^2.6.0",
     "body-parser": "^1.15.2",
     "bootstrap": "^3.3.7",
     "bootstrap-validator": "^0.11.8",

--- a/test/letter-avatars.js
+++ b/test/letter-avatars.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const assert = require('assert');
+const avatars = require('../lib/letter-avatars')
+
+describe('generateAvatarURL()', function() {
+  it('should return correct urls', function() {
+    assert.equal(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=400');
+    assert.equal(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=96');
+  });
+});


### PR DESCRIPTION
This removes the blueimp-md5 hashing module, in favor of the one in the standard library. As requested by @SISheogorath, it also adds a test to see if everything still works (could be a beginning for  #611?). If requested, I'll remove the test again.

Fixes #1106.