### PR TITLE
Update SAML to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "passport-ldapauth": "^2.0.0",
     "passport-local": "^1.0.0",
     "passport-oauth2": "^1.4.0",
-    "passport-saml": "^0.35.0",
+    "passport-saml": "^1.0.0",
     "passport-twitter": "^1.0.4",
     "passport.socketio": "^3.7.0",
     "pdfobject": "^2.0.201604172",


### PR DESCRIPTION
Seems like there was a security problem with the library.

This patch updates to version 1.0.0 which fixed the details.

Details: https://snyk.io/vuln/SNYK-JS-PASSPORTSAML-72411

Signed-off-by: Sheogorath <sheogorath@shivering-isles.com>