### PR TITLE
Fix broken manage_users after Winston upgrade

### DIFF
--- a/bin/manage_users
+++ b/bin/manage_users
@@ -2,7 +2,7 @@
 
 // First configure the logger so it does not spam the console
 const logger = require("../lib/logger");
-logger.transports.console.level = "warning";
+logger.transports.forEach((transport) => transport.level = "warning")
 
 const models = require("../lib/models/");
 const readline = require("readline-sync");


### PR DESCRIPTION
Commit c3584770 upgrades Winston and with that version
`logger.transports.console` becomes undefined. This commit
updates the code to prevent the crash.

As far as I know, no issue was submitted for this bug.