### PR TITLE
Drop node 6.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ jobs:
   include:
     - env: task=npm-test
       node_js:
-        - 6
-      before_install:
-        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
-        - export PATH="$HOME/.yarn/bin:$PATH"
-    - env: task=npm-test
-      node_js:
         - 8
       before_install:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Just to more confusion: We are still friends with HackMD :heart:
 
 ### Prerequisite
 
-- Node.js 6.x or up (test up to 7.5.0) and <10.x
+- Node.js 8.x or up to <=10.x
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm (and its dependencies, especially [uWebSockets](https://github.com/uWebSockets/uWebSockets#nodejs-developers), [node-gyp](https://github.com/nodejs/node-gyp#installation))
 - For **building** CodiMD we recommend to use a machine with at least **2GB** RAM


### PR DESCRIPTION
Seems like one of our deep dependencies dropped node version 6. This
results in a failed execution of yarn, that refuses to install the
library.

Since we already deprecated version 6 in earlier releases, dropping it
is a valid option.