### PR TITLE
Add linting for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "test": "npm run-script eslint && npm run-script jsonlint && mocha",
-    "eslint": "node_modules/.bin/eslint lib public app.js",
+    "eslint": "node_modules/.bin/eslint lib public test app.js",
     "jsonlint": "find . -not -path './node_modules/*' -type f -name '*.json' -o -type f -name '*.json.example' | while read json; do echo $json ; jq . $json; done",
     "standard": "echo 'standard is no longer being used, use `npm run eslint` instead!' && exit 1",
     "dev": "webpack --config webpack.dev.js --progress --colors --watch",

--- a/test/letter-avatars.js
+++ b/test/letter-avatars.js
@@ -1,11 +1,13 @@
+/* eslint-env node, mocha */
+
 'use strict'
 
-const assert = require('assert');
+const assert = require('assert')
 const avatars = require('../lib/letter-avatars')
 
-describe('generateAvatarURL()', function() {
-  it('should return correct urls', function() {
-    assert.equal(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=400');
-    assert.equal(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=96');
-  });
-});
+describe('generateAvatarURL()', function () {
+  it('should return correct urls', function () {
+    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=400')
+    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=96')
+  })
+})


### PR DESCRIPTION
The tests are currently not linted. This causes a different coding style
than the rest of the sources.

This patch adds the `./test` directory to the eslint testing and fixes
linting for existing tests.