### PR TITLE
Fixing deep dependency problem with node 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
     "ws": "^6.0.0",
     "xss": "^1.0.3"
   },
+  "resolutions": {
+    "**/tough-cookie": "~2.4.0"
+  },
   "engines": {
     "node": ">=6.x"
   },


### PR DESCRIPTION
this commit has been blatantly stolen from @samselikoff in ember-cli-addon-docs. It prevents an issue introduced via a deep dependency that no longer supports node 6 (which we still would like to support).
see: https://github.com/ember-learn/ember-cli-addon-docs/commit/231275b5a4bed59bbac798ddaa1bde94319047cb
see: https://github.com/salesforce/tough-cookie/pull/141

The pull request should tell us, if this satisfies Travis.