### PR TITLE
Fix broken PDF export by wrong unlink call

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -320,7 +320,7 @@ function actionPDF (req, res, note) {
     res.setHeader('Content-Type', 'application/pdf; charset=UTF-8')
     res.setHeader('X-Robots-Tag', 'noindex, nofollow') // prevent crawling
     stream.pipe(res)
-    fs.unlink(path)
+    fs.unlinkSync(path)
   })
 }
 


### PR DESCRIPTION
We used `fs.unlink()` to remove the pdf file after we send it out to the 
client. This breaks in Node 10, when no function as second parameter is 
supplied.

This patches changes it to the `fs.unlinkSync` function that doesn't 
have this requirement and this way doesn't crash.