### PR TITLE
Adds support for S3 Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ There are some config settings you need to change in the files below.
 | `allowGravatar` | `true` or `false` | set to `false` to disable gravatar as profile picture source on your instance |
 | `imageUploadType` | `imgur`, `s3`, `minio`, `azure` or `filesystem`(default) | Where to upload images. For S3, see our Image Upload Guides for [S3](docs/guides/s3-image-upload.md) or [Minio](docs/guides/minio-image-upload.md)|
 | `minio` | `{ "accessKey": "YOUR_MINIO_ACCESS_KEY", "secretKey": "YOUR_MINIO_SECRET_KEY", "endpoint": "YOUR_MINIO_HOST", port: 9000, secure: true }` | When `imageUploadType` is set to `minio`, you need to set this key. Also checkout our [Minio Image Upload Guide](docs/guides/minio-image-upload.md) |
-| `s3` | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION" }` | When `imageuploadtype` be set to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
+| `s3` | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION", "domain": "YOURSUBDOMAIN.EXAMPLE.COM" }` | When `imageuploadtype` be set to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
 | `s3bucket` | `YOUR_S3_BUCKET_NAME` | bucket name when `imageUploadType` is set to `s3` or `minio` |
 | `sourceURL` | `https://github.com/hackmdio/codimd/tree/<current commit>` | Provides the link to the source code of CodiMD on the entry page (Please, make sure you change this when you run a modified version) |
 

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -40,7 +40,8 @@ module.exports = {
   s3: {
     accessKeyId: process.env.CMD_S3_ACCESS_KEY_ID,
     secretAccessKey: process.env.CMD_S3_SECRET_ACCESS_KEY,
-    region: process.env.CMD_S3_REGION
+    region: process.env.CMD_S3_REGION,
+    domain: process.env.CMD_S3_DOMAIN
   },
   minio: {
     accessKey: process.env.CMD_MINIO_ACCESS_KEY,

--- a/lib/web/imageRouter/s3.js
+++ b/lib/web/imageRouter/s3.js
@@ -45,7 +45,14 @@ exports.uploadImage = function (imagePath, callback) {
       if (config.s3.region && config.s3.region !== 'us-east-1') {
         s3Endpoint = `s3-${config.s3.region}.amazonaws.com`
       }
-      callback(null, `https://${s3Endpoint}/${config.s3bucket}/${params.Key}`)
+      
+      // if a custom S3 Domain is set, e.g. images.example.com, serve from that domain
+      // Note: only https is supported, SSL must be configured with Cloudfront or Cloudflare
+      if (config.s3.domain) {
+        callback(null, `https://${config.s3.domain}/${params.Key}`)
+      } else {
+        callback(null, `https://${s3Endpoint}/${config.s3bucket}/${params.Key}`)
+      }
     })
   })
 }


### PR DESCRIPTION
Adds a new config setting, S3_DOMAIN, that allows for images hosted on S3 to be hosted from a domain `images.example.com`. Only serves over https, so user will need to configure SSL using Cloudfront or Cloudflare.

imageRouter / s3, config, and README updates

Implements #1128 