### PR TITLE
Fix shown but broken GitLab snippets

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -128,7 +128,7 @@ if (config.gitlab && config.gitlab.version !== 'v4' && config.gitlab.version !==
   config.gitlab.version = 'v4'
 }
 // If gitlab scope is api, enable snippets Export/import
-config.isGitlabSnippetsEnable = (!config.gitlab.scope || config.gitlab.scope === 'api')
+config.isGitlabSnippetsEnable = (!config.gitlab.scope || config.gitlab.scope === 'api') && config.isGitLabEnable
 
 // Only update i18n files in development setups
 config.updateI18nFiles = (env === Environment.development)


### PR DESCRIPTION
To provide a GitLab integration we need the GitLab integration to be
configured. Otherwise we shouldn't show the Snippet button.

This patch adds the requirement to the variable that decides if the
import from snippets button shows up or not.