### PR TITLE
Remove broken speakerdeck embedding

### DIFF
--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -222,9 +222,6 @@ When you’re a carpenter making a beautiful chest of drawers, you’re not goin
 ### SlideShare
 {%slideshare briansolis/26-disruptive-technology-trends-2016-2018-56796196 %}
 
-### Speakerdeck
-{%speakerdeck sugarenia/xxlcss-how-to-scale-css-and-keep-your-sanity %}
-
 ### PDF
 **Caution: this might be blocked by your browser if not using an `https` URL.**
 {%pdf https://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf %}

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -459,34 +459,13 @@ export function finishView (view) {
     // speakerdeck
   view.find('div.speakerdeck.raw').removeClass('raw')
         .each((key, value) => {
-          const url = `https://speakerdeck.com/oembed.json?url=https%3A%2F%2Fspeakerdeck.com%2F${encodeURIComponent($(value).attr('data-speakerdeckid'))}`
-            // use yql because speakerdeck not support jsonp
-          $.ajax({
-            url: 'https://query.yahooapis.com/v1/public/yql',
-            data: {
-              q: `select * from json where url ='${url}'`,
-              format: 'json'
-            },
-            dataType: 'jsonp',
-            success (data) {
-              if (!data.query || !data.query.results) return
-              const json = data.query.results.json
-              const html = json.html
-              var ratio = json.height / json.width
-              $(value).html(html)
-              const iframe = $(value).children('iframe')
-              const src = iframe.attr('src')
-              if (src.indexOf('//') === 0) { iframe.attr('src', `https:${src}`) }
-              const inner = $('<div class="inner"></div>').append(iframe)
-              const height = iframe.attr('height')
-              const width = iframe.attr('width')
-              ratio = (height / width) * 100
-              inner.css('padding-bottom', `${ratio}%`)
-              $(value).html(inner)
-              if (window.viewAjaxCallback) window.viewAjaxCallback()
-            }
-          })
-        })
+          const url = `https://speakerdeck.com/${$(value).attr('data-speakerdeckid')}`
+          const inner = $('<a>Speakerdeck</a>')
+          inner.attr('href', url)
+          inner.attr('rel', 'noopener noreferrer')
+          inner.attr('target', '_blank')
+          $(value).append(inner)
+      })
     // pdf
   view.find('div.pdf.raw').removeClass('raw')
             .each(function (key, value) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,7 +1,6 @@
 /* eslint-env browser, jquery */
-/* global CodeMirror, Cookies, moment, editor, ui, Spinner,
-   modeType, Idle, serverurl, key, gapi, Dropbox, FilePicker
-   ot, MediaUploader, hex2rgb, num_loaded, Visibility */
+/* global CodeMirror, Cookies, moment, Spinner, Idle, serverurl,
+   key, Dropbox, ot, hex2rgb, Visibility */
 
 require('../vendor/showup/showup')
 


### PR DESCRIPTION
The current speakerdeck implementation is broken. An alternative
implementation using oembed doesn't work due to CORS, which could be
solved by proxying the speakerdeck API, but we decided to not do this.

This patch provides the link to the speakerdeck presentation instead,
and this way doesn't break existing notes. This is right now the best
solution we could come up with.