### PR TITLE
Fix empty serverURL did not redirect properly

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -23,7 +23,7 @@ var response = {
       responseError(res, '403', 'Forbidden', 'oh no.')
     } else {
       req.flash('error', 'You are not allowed to access this page. Maybe try logging in?')
-      res.redirect(config.serverURL)
+      res.redirect(config.serverURL + '/')
     }
   },
   errorNotFound: function (res) {


### PR DESCRIPTION
If serverurl is empty and session was expired, redirect doesn’t properly.

302 Found
Location:
