### PR TITLE
Mention dependency on libssl-dev in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Just to more confusion: We are still friends with HackMD :heart:
 - Node.js 6.x or up (test up to 7.5.0) and <10.x
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm (and its dependencies, especially [uWebSockets](https://github.com/uWebSockets/uWebSockets#nodejs-developers), [node-gyp](https://github.com/nodejs/node-gyp#installation))
+- `libssl-dev` for building scrypt (see [here](https://github.com/ml1nk/node-scrypt/blob/master/README.md#installation-instructions) for further information)
 - For **building** CodiMD we recommend to use a machine with at least **2GB** RAM
 
 ### Instructions


### PR DESCRIPTION
I tried to installed CodiMD on a new Debian 9 install. It was difficult to find out the dependency on the package `libssl-dev` introduced by this [commit](https://github.com/hackmdio/codimd/commit/cee2aa92f9244d1dcfc65c5553f5d7f0bbfb3871).

This PR proposes a mention of this dependency in README.md.