### PR TITLE
Revert deletion of cookie "expires"

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,7 +138,8 @@ app.use(session({
   saveUninitialized: true, // always create session to ensure the origin
   rolling: true, // reset maxAge on every response
   cookie: {
-    maxAge: config.sessionLife
+    maxAge: config.sessionLife,
+    expires: new Date(Date.now() + config.sessionLife)
   },
   store: sessionStore
 }))


### PR DESCRIPTION
** This is draft. **
I'm checking another part of express-session.
---

This change is workaround for express-session.
I read [an issue](https://github.com/expressjs/session/issues/365) about session cookies.
But I think there is some bugs about using only "maxAge".
