### PR TITLE
Add required change for Google+ API deprecation

### DIFF
--- a/lib/web/auth/google/index.js
+++ b/lib/web/auth/google/index.js
@@ -11,7 +11,8 @@ let googleAuth = module.exports = Router()
 passport.use(new GoogleStrategy({
   clientID: config.google.clientID,
   clientSecret: config.google.clientSecret,
-  callbackURL: config.serverURL + '/auth/google/callback'
+  callbackURL: config.serverURL + '/auth/google/callback',
+  userProfileURL: "https://www.googleapis.com/oauth2/v3/userinfo"
 }, passportGeneralCallback))
 
 googleAuth.get('/auth/google', function (req, res, next) {


### PR DESCRIPTION
Since Google+ is shutting down soon, we need to get the profile data
from another URL. Since the library already supports it, all we need to
do is adding a single line of code.

Fixes https://github.com/hackmdio/codimd/issues/1160