### PR TITLE
Fix broken HTML export with emojis

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1134,7 +1134,7 @@ const emojijsPlugin = new Plugin(
 
     (match, utils) => {
       const emoji = match[1].toLowerCase()
-      const div = $(`<img class="emoji" src="${serverurl}/build/emojify.js/dist/images/basic/${emoji}.png"></img>`)
+      const div = $(`<img class="emoji" alt=":${emoji}:" src="${serverurl}/build/emojify.js/dist/images/basic/${emoji}.png"></img>`)
       return div[0].outerHTML
     }
 )


### PR DESCRIPTION
HTML export was broken due to missing alt-attribute for emojis.

This patch adds the old alt-element style and restores the exportability
this way.

Fixes #1164 