### PR TITLE
Update history on note creation

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -14,6 +14,7 @@ var config = require('./config')
 var logger = require('./logger')
 var models = require('./models')
 var utils = require('./utils')
+var history = require('./history')
 
 // public
 var response = {
@@ -106,6 +107,12 @@ function responseCodiMD (res, note) {
   })
 }
 
+function updateHistory (userId, note, document, time) {
+  var noteId = note.alias ? note.alias : models.Note.encodeNoteId(note.id)
+  history.updateHistory(userId, noteId, document, time)
+  logger.info("history updated")
+}
+
 function newNote (req, res, next) {
   var owner = null
   var body = ''
@@ -125,6 +132,11 @@ function newNote (req, res, next) {
     alias: req.alias ? req.alias : null,
     content: body
   }).then(function (note) {
+
+    if (req.isAuthenticated()) {
+      updateHistory(owner, note, body);
+    }
+
     return res.redirect(config.serverURL + '/' + models.Note.encodeNoteId(note.id))
   }).catch(function (err) {
     logger.error(err)


### PR DESCRIPTION
When creating a new note with the API, the note doesn't appear in the history. 
If the URL returned by the API is lost, or never accessed, then the note is lost, and the owner can't access it.

This pull request updates the history on note creation.