### PR TITLE
Fix capital letters in language selection

### DIFF
--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -135,20 +135,20 @@
                         <option value="ca">Català</option>
                         <option value="el">Ελληνικά</option>
                         <option value="pt">Português</option>
-                        <option value="it">italiano</option>
+                        <option value="it">Italiano</option>
                         <option value="tr">Türkçe</option>
                         <option value="ru">Русский</option>
                         <option value="nl">Nederlands</option>
-                        <option value="hr">hrvatski jezik</option>
-                        <option value="pl">język polski</option>
+                        <option value="hr">Hrvatski</option>
+                        <option value="pl">Polski</option>
                         <option value="uk">Українська</option>
                         <option value="hi">हिन्दी</option>
-                        <option value="sv">svenska</option>
+                        <option value="sv">Svenska</option>
                         <option value="eo">Esperanto</option>
-                        <option value="da">dansk</option>
+                        <option value="da">Dansk</option>
                         <option value="ko">한국어</option>
                         <option value="id">Bahasa Indonesia</option>
-                        <option value="sr">српски</option>
+                        <option value="sr">Cрпски</option>
                     </select>
                     <p>
                         <%- __('Powered by %s', '<a href="https://codimd.org">CodiMD</a>') %> | <a href="<%- serverURL %>/s/release-notes" target="_blank" rel="noopener"><%= __('Releases') %></a>| <a href="<%- sourceURL %>" target="_blank" rel="noopener"><%= __('Source Code') %></a><% if(privacyStatement) { %> | <a href="<%- serverURL %>/s/privacy" target="_blank" rel="noopener"><%= __('Privacy') %></a><% } %><% if(termsOfUse) { %> | <a href="<%- serverURL %>/s/terms-of-use" target="_blank" rel="noopener"><%= __('Terms of Use') %></a><% } %>


### PR DESCRIPTION
@cvladan gave a hint about some minor problems with the capitalization 
of language names.

This patch should fix most of them. and removes some "language" prefix 
and suffixes which are not needed to make clear what people are 
selecting here.

[1]: https://github.com/cvladan