### PR TITLE
Fix avoiding crash if URL is invalid

### DIFF
--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -16,5 +16,12 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  callback(null, (new URL(path.basename(imagePath), config.serverURL + '/uploads/')).href)
+  let url
+  try {
+    url = (new URL(path.basename(imagePath), config.serverURL + '/uploads/')).href
+  } catch (e) {
+    url = config.serverURL + '/uploads/' + path.basename(imagePath)
+  }
+
+  callback(null, url)
 }


### PR DESCRIPTION
Hi, I encountered codimd crash if url.js throws ERR_INVALID_URL.

```
2019-04-17T09:58:38.426Z error: 	uncaughtException: Invalid URL: /uploads/
TypeError [ERR_INVALID_URL]: Invalid URL: /uploads/
    at onParseError (internal/url.js:219:17)
    at parse (internal/url.js:228:3)
    at new URL (internal/url.js:311:5)
    at new URL (internal/url.js:309:14)
    at Object.exports.uploadImage (/codimd/lib/web/imageRouter/filesystem.js:19:19)
    at /codimd/lib/web/imageRouter/index.js:31:22
    at IncomingForm.<anonymous> (/codimd/node_modules/formidable/lib/incoming_form.js:107:9)
    at emitNone (events.js:106:13)
    at IncomingForm.emit (events.js:208:7)
    at IncomingForm._maybeEnd (/codimd/node_modules/formidable/lib/incoming_form.js:557:8)
    at /codimd/node_modules/formidable/lib/incoming_form.js:238:12
    at WriteStream.<anonymous> (/codimd/node_modules/formidable/lib/file.js:79:5)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
    at WriteStream.emit (events.js:208:7)
    at finishMaybe (_stream_writable.js:613:14)
2019-04-17T09:58:38.426Z error: 	An uncaught exception has occured.
2019-04-17T09:58:38.426Z error: 	Invalid URL: /uploads/
2019-04-17T09:58:38.426Z error: 	Process will exit now.
```

I checked [This issue](https://github.com/codimd/container/issues/23).
However, I think that URL validation check of this file is too strict.

If you allow me to fix as follows, I close this PR and open a new one.
```javascript
callback(null, config.serverURL + '/uploads/' + path.basename(imagePath))
```

What do you think about this?