### PR TITLE
Adding an error code to the `{"status":"forbidden"}` response

### DIFF
--- a/lib/web/userRouter.js
+++ b/lib/web/userRouter.js
@@ -33,7 +33,7 @@ UserRouter.get('/me', function (req, res) {
       return response.errorInternalError(res)
     })
   } else {
-    res.send({
+    res.status(401).send({
       status: 'forbidden'
     })
   }


### PR DESCRIPTION
I think a 401 status code should be more appropriate than 200 when the user is not recognized.