### PR TITLE
Block note creation by anonymous users if allowAnonymousEdits is false

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -124,7 +124,7 @@ function newNote (req, res, next) {
   body = body.replace(/[\r]/g, '')
   if (req.isAuthenticated()) {
     owner = req.user.id
-  } else if (!config.allowAnonymous) {
+  } else if (!config.allowAnonymous || (config.allowAnonymous && !config.allowAnonymousEdits)) {
     return response.errorForbidden(res)
   }
   models.Note.create({

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -12,7 +12,7 @@
                             <li class="ui-history<% if(signin) { %> active<% } %>"><a href="#"><%= __('History') %></a>
                             </li>
                             <div class="ui-signin" style="float: right; margin-top: 8px;<% if(signin) { %> display: none;<% } %>">
-                                <% if (allowAnonymous) { %>
+                                <% if (allowAnonymous && allowAnonymousEdits) { %>
                                 <a type="button" href="<%- serverURL %>/new" class="btn btn-sm btn-primary"><i class="fa fa-plus"></i> <%= __('New guest note') %></a>
                                 <% } %>
                                 <% if (authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.saml || authProviders.oauth2 || authProviders.email) { %>


### PR DESCRIPTION
If anonymous users can't edit notes, they also shouldn't be able to create notes (in my opinion! I don't want to run a public pastebin). This patch should restrict guests from seeing the "New guest note" button on the index page, and sends them to a forbidden page if they try /new, on instances where allowAnonymous=true and allowAnonymousEdits=false.