### PR TITLE
Update the docker deployment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ HackMD team is committed to keep CodiMD open source. All contributions are welco
 You would find all documentation here: [CodiMD Documentation](https://hackmd.io/c/codimd-documentation)
 
 ### Deployment
-If you want to spin up an instance and start using immediately, see [Docker deployment](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-documentation#Deployment).
+If you want to spin up an instance and start using immediately, see [Docker container repository](https://github.com/codimd/container).
 If you want to contribute to the project, start with [manual deployment](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-manual-deployment).
 
 ### Configuration


### PR DESCRIPTION
The archived repository https://github.com/hackmdio/docker-hackmd is very confusing