### PR TITLE
Make toobusy.maxLag configurable

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -56,6 +56,8 @@ module.exports = {
   // socket.io
   heartbeatInterval: 5000,
   heartbeatTimeout: 10000,
+  // toobusy-js
+  responseMaxLag: 70,
   // document
   documentMaxLength: 100000,
   // image upload setting, available options are imgur/s3/filesystem/azure

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -33,6 +33,7 @@ module.exports = {
   dbURL: process.env.CMD_DB_URL,
   sessionSecret: process.env.CMD_SESSION_SECRET,
   sessionLife: toIntegerConfig(process.env.CMD_SESSION_LIFE),
+  responseMaxLag: toIntegerConfig(process.env.CMD_RESPONSE_MAX_LAG),
   imageUploadType: process.env.CMD_IMAGE_UPLOAD_TYPE,
   imgur: {
     clientID: process.env.CMD_IMGUR_CLIENTID

--- a/lib/config/hackmdEnvironment.js
+++ b/lib/config/hackmdEnvironment.js
@@ -28,6 +28,7 @@ module.exports = {
   dbURL: process.env.HMD_DB_URL,
   sessionSecret: process.env.HMD_SESSION_SECRET,
   sessionLife: toIntegerConfig(process.env.HMD_SESSION_LIFE),
+  responseMaxLag: toIntegerConfig(process.env.HMD_RESPONSE_MAX_LAG),
   imageUploadType: process.env.HMD_IMAGE_UPLOAD_TYPE,
   imgur: {
     clientID: process.env.HMD_IMGUR_CLIENTID

--- a/lib/web/middleware/tooBusy.js
+++ b/lib/web/middleware/tooBusy.js
@@ -2,7 +2,10 @@
 
 const toobusy = require('toobusy-js')
 
+const config = require('../../config')
 const response = require('../../response')
+
+toobusy.maxLag(config.responseMaxLag);
 
 module.exports = function (req, res, next) {
   if (toobusy()) {


### PR DESCRIPTION
Make [toobusy-js](https://github.com/STRML/node-toobusy) maxLag parameter configurable with environment variables.
Default value is 70ms.