### PR TITLE
Fix js-sequence-diagrams bundling

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -207,7 +207,7 @@ module.exports = {
       'script-loader!codemirrorInlineAttachment',
       'script-loader!ot',
       'flowchart.js',
-      'script-loader!js-sequence-diagrams',
+      'imports-loader?Raphael=raphael!js-sequence-diagrams',
       'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/index.js')
     ],
@@ -255,7 +255,7 @@ module.exports = {
       'script-loader!codemirrorInlineAttachment',
       'script-loader!ot',
       'flowchart.js',
-      'script-loader!js-sequence-diagrams',
+      'imports-loader?Raphael=raphael!js-sequence-diagrams',
       'expose-loader?Viz!viz.js',
       'script-loader!abcjs',
       'expose-loader?io!socket.io-client',
@@ -265,7 +265,7 @@ module.exports = {
     pretty: [
       'babel-polyfill',
       'flowchart.js',
-      'script-loader!js-sequence-diagrams',
+      'imports-loader?Raphael=raphael!js-sequence-diagrams',
       'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/pretty.js')
     ],
@@ -290,7 +290,7 @@ module.exports = {
       'expose-loader?emojify!emojify.js',
       'script-loader!gist-embed',
       'flowchart.js',
-      'script-loader!js-sequence-diagrams',
+      'imports-loader?Raphael=raphael!js-sequence-diagrams',
       'expose-loader?Viz!viz.js',
       'script-loader!abcjs',
       'expose-loader?RevealMarkdown!reveal-markdown',
@@ -300,7 +300,7 @@ module.exports = {
       'babel-polyfill',
       'bootstrap-tooltip',
       'flowchart.js',
-      'script-loader!js-sequence-diagrams',
+      'imports-loader?Raphael=raphael!js-sequence-diagrams',
       'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/slide.js')
     ],
@@ -328,7 +328,7 @@ module.exports = {
       'expose-loader?emojify!emojify.js',
       'script-loader!gist-embed',
       'flowchart.js',
-      'script-loader!js-sequence-diagrams',
+      'imports-loader?Raphael=raphael!js-sequence-diagrams',
       'expose-loader?Viz!viz.js',
       'script-loader!abcjs',
       'headjs',


### PR DESCRIPTION
Error:

```
[Script Loader] ReferenceError: Raphael is not defined
    at Module.eval (eval at module.exports (addScript.js?f2b5:27), <anonymous>:1:113133)
    at e (eval at module.exports (addScript.js?f2b5:27), <anonymous>:1:110)
    at eval (eval at module.exports (addScript.js?f2b5:27), <anonymous>:1:902)
    at eval (eval at module.exports (addScript.js?f2b5:27), <anonymous>:1:913)
    at eval (<anonymous>)
    at module.exports (addScript.js?f2b5:20)
    at eval (main.js?b289:1)
    at Object../node_modules/script-loader/index.js!./node_modules/@hackmd/js-sequence-diagrams/build/main.js (index-pack.js:12798)
    at __webpack_require__ (index-pack.js:20)
    at Object.8 (index-pack.js:13991)
```