### PR TITLE
Remove BUILD_ASSETS environment variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,10 +11,6 @@
     "logo": "https://github.com/hackmdio/codimd/raw/master/public/codimd-icon-1024.png",
     "success_url": "/",
     "env": {
-        "BUILD_ASSETS": {
-            "description": "Our build script variable",
-            "value": "true"
-        },
         "NPM_CONFIG_PRODUCTION": {
             "description": "Let npm also install development build tool",
             "value": "false"

--- a/bin/heroku
+++ b/bin/heroku
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "$BUILD_ASSETS" = true ]; then
+if [ ! -z "$DYNO" ]; then
   # setup config files
   cat << EOF > .sequelizerc
 var path = require('path');


### PR DESCRIPTION
### Changes

Remove unnecessary `BUILD_ASSETS` environment variable. We can check whether it runs on heroku by the `DYNO` env 