### PR TITLE
Add https_proxy support to gitlab oauth

### DIFF
--- a/lib/web/auth/gitlab/index.js
+++ b/lib/web/auth/gitlab/index.js
@@ -6,11 +6,11 @@ const GitlabStrategy = require('passport-gitlab2').Strategy
 const config = require('../../../config')
 const response = require('../../../response')
 const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
-const HttpsProxyAgent = require('https-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent')
 
 const gitlabAuth = module.exports = Router()
 
-let gitlabAuthStrategy = new GitlabStrategy({
+const gitlabAuthStrategy = new GitlabStrategy({
   baseURL: config.gitlab.baseURL,
   clientID: config.gitlab.clientID,
   clientSecret: config.gitlab.clientSecret,
@@ -19,8 +19,8 @@ let gitlabAuthStrategy = new GitlabStrategy({
 }, passportGeneralCallback)
 
 if (process.env['https_proxy']) {
-  let httpsProxyAgent = new HttpsProxyAgent(process.env['https_proxy']);
-  gitlabAuthStrategy._oauth2.setAgent(httpsProxyAgent);
+  const httpsProxyAgent = new HttpsProxyAgent(process.env['https_proxy'])
+  gitlabAuthStrategy._oauth2.setAgent(httpsProxyAgent)
 }
 
 passport.use(gitlabAuthStrategy)

--- a/lib/web/auth/gitlab/index.js
+++ b/lib/web/auth/gitlab/index.js
@@ -6,16 +6,24 @@ const GitlabStrategy = require('passport-gitlab2').Strategy
 const config = require('../../../config')
 const response = require('../../../response')
 const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const HttpsProxyAgent = require('https-proxy-agent');
 
 const gitlabAuth = module.exports = Router()
 
-passport.use(new GitlabStrategy({
+let gitlabAuthStrategy = new GitlabStrategy({
   baseURL: config.gitlab.baseURL,
   clientID: config.gitlab.clientID,
   clientSecret: config.gitlab.clientSecret,
   scope: config.gitlab.scope,
   callbackURL: config.serverURL + '/auth/gitlab/callback'
-}, passportGeneralCallback))
+}, passportGeneralCallback)
+
+if (process.env['https_proxy']) {
+  let httpsProxyAgent = new HttpsProxyAgent(process.env['https_proxy']);
+  gitlabAuthStrategy._oauth2.setAgent(httpsProxyAgent);
+}
+
+passport.use(gitlabAuthStrategy)
 
 gitlabAuth.get('/auth/gitlab', function (req, res, next) {
   setReturnToFromReferer(req)

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "handlebars": "~4.1.2",
     "helmet": "~3.20.0",
     "highlight.js": "~9.15.9",
+    "https-proxy-agent": "^3.0.1",
     "i18n": "~0.8.3",
     "ionicons": "~2.0.1",
     "isomorphic-fetch": "~2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6442,6 +6442,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz#b8c286433e87602311b01c8ea34413d856a4af81"
+  integrity sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
+
 i18n@~0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/i18n/-/i18n-0.8.3.tgz#2d8cf1c24722602c2041d01ba6ae5eaa51388f0e"


### PR DESCRIPTION
fixes #1295 

This adds support for GitLab OAuth where the GitLab server is behind a corporate proxy.

It checks for the `https_proxy` environment variable, and if it exists, will use that value as the HTTPS proxy.