### PR TITLE
Configurable default break style

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -162,5 +162,6 @@ module.exports = {
   allowEmailRegister: true,
   allowGravatar: true,
   allowPDFExport: true,
-  openID: false
+  openID: false,
+  defaultUseHardbreak: true
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -135,5 +135,6 @@ module.exports = {
   allowEmailRegister: toBooleanConfig(process.env.CMD_ALLOW_EMAIL_REGISTER),
   allowGravatar: toBooleanConfig(process.env.CMD_ALLOW_GRAVATAR),
   allowPDFExport: toBooleanConfig(process.env.CMD_ALLOW_PDF_EXPORT),
-  openID: toBooleanConfig(process.env.CMD_OPENID)
+  openID: toBooleanConfig(process.env.CMD_OPENID),
+  defaultUseHardbreak: toBooleanConfig(process.env.CMD_DEFAULT_USE_HARD_BREAK)
 }

--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -99,7 +99,8 @@ statusRouter.get('/config', function (req, res) {
     version: config.fullversion,
     plantumlServer: config.plantuml.server,
     DROPBOX_APP_KEY: config.dropbox.appKey,
-    allowedUploadMimeTypes: config.allowedUploadMimeTypes
+    allowedUploadMimeTypes: config.allowedUploadMimeTypes,
+    defaultUseHardbreak: config.defaultUseHardbreak
   }
   res.set({
     'Cache-Control': 'private', // only cache by client

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -195,7 +195,7 @@ export function isValidURL (str) {
 export function parseMeta (md, edit, view, toc, tocAffix) {
   let lang = null
   let dir = null
-  let breaks = true
+  let breaks = window.defaultUseHardbreak
   if (md && md.meta) {
     const meta = md.meta
     lang = meta.lang
@@ -225,10 +225,10 @@ export function parseMeta (md, edit, view, toc, tocAffix) {
     tocAffix.removeAttr('dir')
   }
   // breaks
-  if (typeof breaks === 'boolean' && !breaks) {
-    md.options.breaks = false
+  if (typeof breaks === 'boolean') {
+    md.options.breaks = breaks
   } else {
-    md.options.breaks = true
+    md.options.breaks = window.defaultUseHardbreak
   }
 }
 
@@ -979,7 +979,7 @@ function highlightRender (code, lang) {
 
 export const md = markdownit('default', {
   html: true,
-  breaks: true,
+  breaks: window.defaultUseHardbreak,
   langPrefix: '',
   linkify: true,
   typographer: true,

--- a/public/js/lib/common/constant.ejs
+++ b/public/js/lib/common/constant.ejs
@@ -6,4 +6,6 @@ window.plantumlServer = '<%- plantumlServer %>'
 
 window.allowedUploadMimeTypes = <%- JSON.stringify(allowedUploadMimeTypes) %>
 
+window.defaultUseHardbreak = <%- defaultUseHardbreak %>
+
 window.DROPBOX_APP_KEY = '<%- DROPBOX_APP_KEY %>'

--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -49,6 +49,15 @@ const deps = [{
   }
 }]
 
+// options from yaml meta
+const meta = JSON.parse($('#meta').text())
+// breaks
+if (typeof meta.breaks === 'boolean') {
+  md.options.breaks = meta.breaks
+} else {
+  md.options.breaks = window.defaultUseHardbreak
+}
+
 const slideOptions = {
   separator: '^(\r\n?|\n)---(\r\n?|\n)$',
   verticalSeparator: '^(\r\n?|\n)----(\r\n?|\n)$'
@@ -70,8 +79,6 @@ const defaultOptions = {
   dependencies: deps
 }
 
-// options from yaml meta
-const meta = JSON.parse($('#meta').text())
 var options = meta.slideOptions || {}
 
 if (Object.hasOwnProperty.call(options, 'spotlight')) {
@@ -102,12 +109,6 @@ if (meta.dir && typeof meta.dir === 'string' && meta.dir === 'rtl') {
   options.rtl = true
 } else {
   options.rtl = false
-}
-// breaks
-if (typeof meta.breaks === 'boolean' && !meta.breaks) {
-  md.options.breaks = false
-} else {
-  md.options.breaks = true
 }
 
 // options from URL query string


### PR DESCRIPTION
resolves #1212 

### Changes

This PR introduce a new configuration entry let you follow CommonMark spec break behavior:

|Set `config.defaultUseHardbreak` to `true` <br> (Current CodiMD implementation) | Set `config.defaultUseHardbreak` to `false` <br> (CommonMark)|
|--|--|
|![Screen Shot 2019-10-20 at 2 22 00 PM](https://user-images.githubusercontent.com/4230968/67155637-9f27f600-f345-11e9-8ed7-74c17f024de1.png)|![Screen Shot 2019-10-20 at 2 22 39 PM](https://user-images.githubusercontent.com/4230968/67155641-bcf55b00-f345-11e9-87d6-f34f8788bc58.png)|

Notice that we keep the default `defaultUseHardbreak` value to `true` for preserving the current behavior.

### TODOs

- [ ] Update documentation

### Ref

- https://github.com/jdhoek/codimd/commit/c12a8d2fddf496966f64ccabc688f3a09320ea90 in https://github.com/hackmdio/codimd/issues/1212#issuecomment-500800293
