### PR TITLE
Allow to generate lower case header references through the config

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -127,6 +127,7 @@
         "plantuml":
         {
           "server": "https://www.plantuml.com/plantuml"
-        }
+        },
+        "linkifyHeaderStyle": "gfm"
     }
 }

--- a/config.json.example
+++ b/config.json.example
@@ -3,7 +3,8 @@
         "db": {
             "dialect": "sqlite",
             "storage": ":memory:"
-        }
+        },
+        "linkifyHeaderStyle": "gfm"
     },
     "development": {
         "loglevel": "debug",
@@ -13,7 +14,8 @@
         "db": {
             "dialect": "sqlite",
             "storage": "./db.codimd.sqlite"
-        }
+        },
+        "linkifyHeaderStyle": "gfm"
     },
     "production": {
         "domain": "localhost",

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -162,5 +162,6 @@ module.exports = {
   allowEmailRegister: true,
   allowGravatar: true,
   allowPDFExport: true,
-  openID: false
+  openID: false,
+  linkifyHeaderStyle: 'keep-case'
 }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -163,5 +163,18 @@ module.exports = {
   allowGravatar: true,
   allowPDFExport: true,
   openID: false,
+  // linkifyHeaderStyle - How is a header text converted into a link id.
+  // Header Example: "3.1. Good Morning my Friend! - Do you have 5$?"
+  // * 'keep-case' is the legacy CodiMD value.
+  //    Generated id: "31-Good-Morning-my-Friend---Do-you-have-5"
+  // * 'lower-case' is the same like legacy (see above), but converted to lower-case.
+  //    Generated id: "#31-good-morning-my-friend---do-you-have-5"
+  // * 'gfm' _GitHub-Flavored Markdown_ style as described here:
+  //    https://gist.github.com/asabaylus/3071099#gistcomment-1593627
+  //    It works like 'lower-case', but making sure the ID is unique.
+  //    This is What GitHub, GitLab and (hopefully) most other tools use.
+  //    Generated id:   "31-good-morning-my-friend---do-you-have-5"
+  //    2nd appearance: "31-good-morning-my-friend---do-you-have-5-1"
+  //    3rd appearance: "31-good-morning-my-friend---do-you-have-5-2"
   linkifyHeaderStyle: 'keep-case'
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -135,5 +135,6 @@ module.exports = {
   allowEmailRegister: toBooleanConfig(process.env.CMD_ALLOW_EMAIL_REGISTER),
   allowGravatar: toBooleanConfig(process.env.CMD_ALLOW_GRAVATAR),
   allowPDFExport: toBooleanConfig(process.env.CMD_ALLOW_PDF_EXPORT),
-  openID: toBooleanConfig(process.env.CMD_OPENID)
+  openID: toBooleanConfig(process.env.CMD_OPENID),
+  linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE
 }

--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -99,7 +99,8 @@ statusRouter.get('/config', function (req, res) {
     version: config.fullversion,
     plantumlServer: config.plantuml.server,
     DROPBOX_APP_KEY: config.dropbox.appKey,
-    allowedUploadMimeTypes: config.allowedUploadMimeTypes
+    allowedUploadMimeTypes: config.allowedUploadMimeTypes,
+    linkifyHeaderStyle: config.linkifyHeaderStyle
   }
   res.set({
     'Cache-Control': 'private', // only cache by client

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -867,7 +867,11 @@ const linkifyAnchors = (level, containingElement) => {
     if (header.getElementsByClassName('anchor').length === 0) {
       if (typeof header.id === 'undefined' || header.id === '') {
         // to escape characters not allow in css and humanize
-        const id = slugifyWithUTF8(getHeaderContent(header))
+        var id = slugifyWithUTF8(getHeaderContent(header))
+        // to make compatible with GitHub, GitLab, Pandoc and many more
+        if (window.linkifyHeaderStyle !== 'keep-case') {
+          id = id.toLowerCase()
+        }
         header.id = id
       }
       if (!(typeof header.id === 'undefined' || header.id === '')) {

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -943,7 +943,7 @@ export function deduplicatedHeaderId (view) {
     // all headers contained in the document, in order of appearance
     const allHeaders = view.find(`:header`).toArray()
     // list of finaly assigned header IDs
-    let headerIds = new Set()
+    const headerIds = new Set()
     for (let j = 0; j < allHeaders.length; j++) {
       const $header = $(allHeaders[j])
       const id = $header.attr('id')

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -867,7 +867,7 @@ const linkifyAnchors = (level, containingElement) => {
     if (header.getElementsByClassName('anchor').length === 0) {
       if (typeof header.id === 'undefined' || header.id === '') {
         // to escape characters not allow in css and humanize
-        var id = slugifyWithUTF8(getHeaderContent(header))
+        let id = slugifyWithUTF8(getHeaderContent(header))
         // to make compatible with GitHub, GitLab, Pandoc and many more
         if (window.linkifyHeaderStyle !== 'keep-case') {
           id = id.toLowerCase()

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -860,7 +860,6 @@ const anchorForId = id => {
 }
 
 const createHeaderId = (headerContent, headerIds = null) => {
-
   // to escape characters not allow in css and humanize
   const slug = slugifyWithUTF8(headerContent)
   let id
@@ -873,13 +872,13 @@ const createHeaderId = (headerContent, headerIds = null) => {
     // see GitHub implementation reference:
     // https://gist.github.com/asabaylus/3071099#gistcomment-1593627
     // it works like 'lower-case', but ...
-    const id_base = slug.toLowerCase()
-    id = id_base
+    const idBase = slug.toLowerCase()
+    id = idBase
     if (headerIds !== null) {
       // ... making sure the id is unique
       let i = 1
       while (headerIds.has(id)) {
-        id = id_base + '-' + i
+        id = idBase + '-' + i
         i++
       }
       headerIds.add(id)
@@ -924,7 +923,6 @@ function getHeaderContent (header) {
 }
 
 function changeHeaderId ($header, id, newId) {
-
   $header.attr('id', newId)
   const $headerLink = $header.find(`> a.anchor[href="#${id}"]`)
   $headerLink.attr('href', `#${newId}`)
@@ -932,11 +930,10 @@ function changeHeaderId ($header, id, newId) {
 }
 
 export function deduplicatedHeaderId (view) {
-
   // headers contained in the last change
   const headers = view.find(':header.raw').removeClass('raw').toArray()
-  if (headers.length == 0) {
-    return;
+  if (headers.length === 0) {
+    return
   }
   if (window.linkifyHeaderStyle === 'gfm') {
     // consistent with GitHub, GitLab, Pandoc & co.

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -168,11 +168,11 @@ export function renderTags (view) {
 }
 
 function slugifyWithUTF8 (text) {
-  // remove html tags and trim spaces
+  // remove HTML tags and trim spaces
   let newText = stripTags(text.toString().trim())
-  // replace all spaces in between to dashes
+  // replace space between words with dashes
   newText = newText.replace(/\s+/g, '-')
-  // slugify string to make it valid for attribute
+  // slugify string to make it valid as an attribute
   newText = newText.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '')
   return newText
 }

--- a/public/js/lib/common/constant.ejs
+++ b/public/js/lib/common/constant.ejs
@@ -6,4 +6,6 @@ window.plantumlServer = '<%- plantumlServer %>'
 
 window.allowedUploadMimeTypes = <%- JSON.stringify(allowedUploadMimeTypes) %>
 
+window.linkifyHeaderStyle = <%- JSON.stringify(linkifyHeaderStyle) %>
+
 window.DROPBOX_APP_KEY = '<%- DROPBOX_APP_KEY %>'

--- a/public/js/lib/common/constant.ejs
+++ b/public/js/lib/common/constant.ejs
@@ -6,6 +6,6 @@ window.plantumlServer = '<%- plantumlServer %>'
 
 window.allowedUploadMimeTypes = <%- JSON.stringify(allowedUploadMimeTypes) %>
 
-window.linkifyHeaderStyle = <%- JSON.stringify(linkifyHeaderStyle) %>
+window.linkifyHeaderStyle = '<%- linkifyHeaderStyle %>'
 
 window.DROPBOX_APP_KEY = '<%- DROPBOX_APP_KEY %>'


### PR DESCRIPTION
resolves #1305 

This makes the references consistent/compatible with GitHub,
GitLab, Pandoc and many other tools.
    
This behavior can be enabled in config.json with:
    
```
"linkifyHeaderStyle": "gfm"
```