### PR TITLE
fix: image upload caused permission denied error in docker

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -18,6 +18,6 @@ RUN set -xe && \
 FROM hackmdio/runtime:1.0.4
 USER hackmd
 WORKDIR /home/hackmd/app
-COPY --from=BUILD /home/hackmd/app .
+COPY --chown=1500:1500 --from=BUILD /home/hackmd/app .
 EXPOSE 3000
 ENTRYPOINT ["/home/hackmd/app/docker-entrypoint.sh"]


### PR DESCRIPTION
fixed wrong file permission setting in 1.4.0-rc.1 caused user can't upload image