### PR TITLE
fix pcheck not parsed url correctly

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -15,7 +15,7 @@ RUN set -xe && \
         yarn.lock webpack.prod.js webpack.htmlexport.js webpack.dev.js webpack.common.js \
         config.json.example README.md CONTRIBUTING.md AUTHORS
 
-FROM hackmdio/runtime:1.0.4
+FROM hackmdio/runtime:1.0.6
 USER hackmd
 WORKDIR /home/hackmd/app
 COPY --chown=1500:1500 --from=BUILD /home/hackmd/app .

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "database-data:/var/lib/postgresql/data"
     restart: always
   codimd:
+    # you can use image or custom build below
+    # image: nabo.codimd.dev/hackmdio/hackmd:1.4.0
     build:
       context: ..
       dockerfile: ./deployments/Dockerfile

--- a/deployments/docker-entrypoint.sh
+++ b/deployments/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [[ "$#" -gt 0 ]]; then
 fi
 
 # check database and redis is ready
-pcheck -constr "$CMD_DB_URL"
+pcheck -env CMD_DB_URL
 
 # run DB migrate
 NEED_MIGRATE=${CMD_AUTO_MIGRATE:=true}


### PR DESCRIPTION
fixed #1347, 
fixed #1351 

1. upgrade node.js version from 8.16.0 to 8.16.2
2. upgrade pcheck to support connection string from environment
3. upgrade pcheck to fix connection string contains underscore might not resolve correctly