### PR TITLE
Explicitely set uploaded image ACLs for S3 to "public-read"

### DIFF
--- a/lib/web/imageRouter/s3.js
+++ b/lib/web/imageRouter/s3.js
@@ -29,7 +29,8 @@ exports.uploadImage = function (imagePath, callback) {
     const params = {
       Bucket: config.s3bucket,
       Key: path.join('uploads', path.basename(imagePath)),
-      Body: buffer
+      Body: buffer,
+      ACL: 'public-read'
     }
 
     const mimeType = getImageMimeType(imagePath)


### PR DESCRIPTION
This works around permission problems with DigitalOcean spaces (where files are always *private* by default).

This should not pose a difference with AWS and other providers as CodiMD only works with public S3 assets either way.