### PR TITLE
Add bitbucket Support

### DIFF
--- a/app.js
+++ b/app.js
@@ -186,6 +186,7 @@ app.locals.authProviders = {
   facebook: config.isFacebookEnable,
   twitter: config.isTwitterEnable,
   github: config.isGitHubEnable,
+  bitbucket: config.isBitbucketEnable,
   gitlab: config.isGitLabEnable,
   mattermost: config.isMattermostEnable,
   dropbox: config.isDropboxEnable,

--- a/app.json
+++ b/app.json
@@ -80,6 +80,14 @@
             "description": "GitHub API client secret",
             "required": false
         },
+        "HMD_BITBUCKET_CLIENTID": {
+            "description": "Bitbucket API client id",
+            "required": false
+        },
+        "HMD_BITBUCKET_CLIENTSECRET": {
+            "description": "Bitbucket API client secret",
+            "required": false
+        },
         "HMD_GITLAB_BASEURL": {
             "description": "GitLab authentication endpoint, set to use other endpoint than GitLab.com (optional)",
             "required": false

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -70,6 +70,10 @@ module.exports = {
     clientID: process.env.CMD_GITHUB_CLIENTID,
     clientSecret: process.env.CMD_GITHUB_CLIENTSECRET
   },
+  bitbucket: {
+    clientID: process.env.CMD_BITBUCKET_CLIENTID,
+    clientSecret: process.env.CMD_BITBUCKET_CLIENTSECRET
+  },
   gitlab: {
     baseURL: process.env.CMD_GITLAB_BASEURL,
     clientID: process.env.CMD_GITLAB_CLIENTID,

--- a/lib/config/hackmdEnvironment.js
+++ b/lib/config/hackmdEnvironment.js
@@ -62,6 +62,10 @@ module.exports = {
     clientID: process.env.HMD_GITHUB_CLIENTID,
     clientSecret: process.env.HMD_GITHUB_CLIENTSECRET
   },
+  bitbucket: {
+    clientID: process.env.HMD_BITBUCKET_CLIENTID,
+    clientSecret: process.env.HMD_BITBUCKET_CLIENTSECRET
+  },
   gitlab: {
     baseURL: process.env.HMD_GITLAB_BASEURL,
     clientID: process.env.HMD_GITLAB_CLIENTID,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -121,6 +121,7 @@ config.isTwitterEnable = config.twitter.consumerKey && config.twitter.consumerSe
 config.isEmailEnable = config.email
 config.isOpenIDEnable = config.openID
 config.isGitHubEnable = config.github.clientID && config.github.clientSecret
+config.isBitbucketEnable = config.bitbucket.clientID && config.bitbucket.clientSecret
 config.isGitLabEnable = config.gitlab.clientID && config.gitlab.clientSecret
 config.isMattermostEnable = config.mattermost.clientID && config.mattermost.clientSecret
 config.isLDAPEnable = config.ldap.url

--- a/lib/web/auth/bitbucket/index.js
+++ b/lib/web/auth/bitbucket/index.js
@@ -4,16 +4,14 @@ const Router = require('express').Router
 const passport = require('passport')
 const BitbucketStrategy = require('passport-bitbucket-oauth2').Strategy
 const config = require('../../../config')
-const response = require('../../../response')
 const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
-const { URL } = require('url')
 
 const bitbucketAuth = module.exports = Router()
 
 passport.use(new BitbucketStrategy({
   clientID: config.bitbucket.clientID,
   clientSecret: config.bitbucket.clientSecret,
-  callbackURL: config.serverURL + '/auth/bitbucket/callback',
+  callbackURL: config.serverURL + '/auth/bitbucket/callback'
 }, passportGeneralCallback))
 
 bitbucketAuth.get('/auth/bitbucket', function (req, res, next) {
@@ -25,6 +23,6 @@ bitbucketAuth.get('/auth/bitbucket', function (req, res, next) {
 bitbucketAuth.get('/auth/bitbucket/callback',
   passport.authenticate('bitbucket', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/' 
+    failureRedirect: config.serverURL + '/'
   })
 )

--- a/lib/web/auth/bitbucket/index.js
+++ b/lib/web/auth/bitbucket/index.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const Router = require('express').Router
+const passport = require('passport')
+const BitbucketStrategy = require('passport-bitbucket-oauth2').Strategy
+const config = require('../../../config')
+const response = require('../../../response')
+const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { URL } = require('url')
+
+const bitbucketAuth = module.exports = Router()
+
+passport.use(new BitbucketStrategy({
+  clientID: config.bitbucket.clientID,
+  clientSecret: config.bitbucket.clientSecret,
+  callbackURL: config.serverURL + '/auth/bitbucket/callback',
+}, passportGeneralCallback))
+
+bitbucketAuth.get('/auth/bitbucket', function (req, res, next) {
+  setReturnToFromReferer(req)
+  passport.authenticate('bitbucket')(req, res, next)
+})
+
+// bitbucket auth callback
+bitbucketAuth.get('/auth/bitbucket/callback',
+  passport.authenticate('bitbucket', {
+    successReturnToOrRedirect: config.serverURL + '/',
+    failureRedirect: config.serverURL + '/' 
+  })
+)

--- a/lib/web/auth/index.js
+++ b/lib/web/auth/index.js
@@ -37,6 +37,7 @@ passport.deserializeUser(function (id, done) {
 if (config.isFacebookEnable) authRouter.use(require('./facebook'))
 if (config.isTwitterEnable) authRouter.use(require('./twitter'))
 if (config.isGitHubEnable) authRouter.use(require('./github'))
+if (config.isBitbucketEnable) authRouter.use(require('./bitbucket'))
 if (config.isGitLabEnable) authRouter.use(require('./gitlab'))
 if (config.isMattermostEnable) authRouter.use(require('./mattermost'))
 if (config.isDropboxEnable) authRouter.use(require('./dropbox'))

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "passport-dropbox-oauth2": "~1.1.0",
     "passport-facebook": "~2.1.1",
     "passport-github": "~1.1.0",
+    "passport-bitbucket-oauth2": "~0.1.2",
     "passport-gitlab2": "~4.0.0",
     "passport-google-oauth20": "~1.0.0",
     "passport-ldapauth": "~2.1.3",

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -15,7 +15,7 @@
                                 <% if (allowAnonymous) { %>
                                 <a type="button" href="<%- serverURL %>/new" class="btn btn-sm btn-primary"><i class="fa fa-plus"></i> <%= __('New guest note') %></a>
                                 <% } %>
-                                <% if (authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.saml || authProviders.oauth2 || authProviders.email) { %>
+                                <% if (authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.bitbucket || authProviders.gitlab ||authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.saml || authProviders.oauth2 || authProviders.email) { %>
                                 <button class="btn btn-sm btn-success ui-signin" data-toggle="modal" data-target=".signin-modal"><%= __('Sign In') %></button>
                                 <% } %>
                             </div>
@@ -50,7 +50,7 @@
                     <% if (errorMessage && errorMessage.length > 0) { %>
                     <div class="alert alert-danger" style="max-width: 400px; margin: 0 auto;"><%= errorMessage %></div>
                     <% } %>
-                    <% if (authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.saml || authProviders.oauth2 || authProviders.email) { %>
+                    <% if (authProviders.facebook || authProviders.twitter || authProviders.github|| authProviders.bitbucket || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.saml || authProviders.oauth2 || authProviders.email) { %>
                     <span class="ui-signin">
                         <br>
                         <a type="button" class="btn btn-lg btn-success ui-signin" data-toggle="modal" data-target=".signin-modal" style="min-width: 200px;"><%= __('Sign In') %></a>

--- a/public/views/shared/signin-modal.ejs
+++ b/public/views/shared/signin-modal.ejs
@@ -23,6 +23,11 @@
                     <i class="fa fa-github"></i> <%= __('Sign in via %s', 'GitHub') %>
                 </a>
                 <% } %>
+                <% if (authProviders.bitbucket) { %>
+                <a href="<%- serverURL %>/auth/bitbucket" class="btn btn-lg btn-block btn-social btn-bitbucket">
+                    <i class="fa fa-bitbucket"></i> <%= __('Sign in via %s', 'Bitbucket') %>
+                </a>
+                <% } %>
                 <% if (authProviders.gitlab) { %>
                 <a href="<%- serverURL %>/auth/gitlab" class="btn btn-lg btn-block btn-social btn-gitlab">
                     <i class="fa fa-gitlab"></i> <%= __('Sign in via %s', 'GitLab') %>
@@ -53,7 +58,7 @@
                     <i class="fa fa-mail-forward"></i> <%= __('Sign in via %s', authProviders.oauth2ProviderName || 'OAuth2') %>
                 </a>
                 <% } %>
-                <% if ((authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.saml || authProviders.oauth2) && authProviders.ldap) { %>
+                <% if ((authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.bitbucket || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.saml || authProviders.oauth2) && authProviders.ldap) { %>
                 <hr>
                 <% }%>
                 <% if (authProviders.ldap) { %>
@@ -78,7 +83,7 @@
                     </div>
                 </form>
                 <% } %>
-                <% if ((authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.oauth2) && authProviders.openID) { %>
+                <% if ((authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.bitbucket || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.oauth2) && authProviders.openID) { %>
                 <hr>
                 <% }%>
                 <% if (authProviders.openID) { %>
@@ -97,7 +102,7 @@
                     </div>
                 </form>
                 <% } %>
-                <% if ((authProviders.facebook || authProviders.twitter || authProviders.github || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.oauth2 || authProviders.openID) && authProviders.email) { %>
+                <% if ((authProviders.facebook || authProviders.twitter || authProviders.github|| authProviders.bitbucket || authProviders.gitlab || authProviders.mattermost || authProviders.dropbox || authProviders.google || authProviders.ldap || authProviders.oauth2 || authProviders.openID) && authProviders.email) { %>
                 <hr>
                 <% }%>
                 <% if (authProviders.email) { %>

--- a/scalingo.json
+++ b/scalingo.json
@@ -80,6 +80,14 @@
             "description": "GitHub API client secret",
             "required": false
         },
+        "CMD_BITBUCKET_CLIENTID": {
+            "description": "Bitbucket API client id",
+            "required": false
+        },
+        "CMD_BITBUCKET_CLIENTSECRET": {
+            "description": "Bitbucket API client secret",
+            "required": false
+        },
         "CMD_GITLAB_BASEURL": {
             "description": "GitLab authentication endpoint, set to use other endpoint than GitLab.com (optional)",
             "required": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -9357,6 +9357,14 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+passport-bitbucket-oauth2@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/passport-bitbucket-oauth2/-/passport-bitbucket-oauth2-0.1.2.tgz#eb3af5cdd0d06830adc49b76acae4ad82290693b"
+  integrity sha1-6zr1zdDQaDCtxJt2rK5K2CKQaTs=
+  dependencies:
+    passport-oauth2 "^1.1.2"
+    pkginfo "0.2.x"
+
 passport-dropbox-oauth2@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/passport-dropbox-oauth2/-/passport-dropbox-oauth2-1.1.0.tgz#77c737636e4841944dfb82dfc42c3d8ab782c10e"
@@ -9419,7 +9427,7 @@ passport-oauth1@1.x.x:
     passport-strategy "1.x.x"
     utils-merge "1.x.x"
 
-passport-oauth2@1.x.x, passport-oauth2@^1.4.0:
+passport-oauth2@1.x.x, passport-oauth2@^1.1.2, passport-oauth2@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/passport-oauth2/-/passport-oauth2-1.5.0.tgz#64babbb54ac46a4dcab35e7f266ed5294e3c4108"
   integrity sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==
@@ -9719,7 +9727,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkginfo@^0.2.3:
+pkginfo@0.2.x, pkginfo@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.2.3.tgz#7239c42a5ef6c30b8f328439d9b9ff71042490f8"
   integrity sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=


### PR DESCRIPTION
Some companies use atlassian cloud and it would be useful if the members can use CodiMD with bitbucket account.

----

#### demo

We can deploy the CodiMD with Bitbucket suuport with the Heroku deploy link below:

https://heroku.com/deploy?template=https://github.com/YusukeIwaki/codimd/tree/feature/bitbucket_login

<img width="1607" alt="貼り付けた画像_2019_12_28_22_30" src="https://user-images.githubusercontent.com/11763113/71544348-b4627600-29c1-11ea-9127-2096a7ef59b0.png">

<img width="1085" alt="貼り付けた画像_2019_12_28_22_31" src="https://user-images.githubusercontent.com/11763113/71544358-e2e05100-29c1-11ea-9c2e-ef0749669e92.png">

<img width="1094" alt="貼り付けた画像_2019_12_28_22_32" src="https://user-images.githubusercontent.com/11763113/71544368-fe4b5c00-29c1-11ea-8cd4-7bbab4d1a2ec.png">
