### PR TITLE
Version check middleware & logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ var response = require('./lib/response')
 var models = require('./lib/models')
 var csp = require('./lib/csp')
 
-const { versionCheckMiddleware } = require('./lib/web/middleware/checkVersion')
+const { versionCheckMiddleware, checkVersion } = require('./lib/web/middleware/checkVersion')
 
 function createHttpServer () {
   if (config.useSSL) {
@@ -170,6 +170,7 @@ app.use(require('./lib/middleware/redirectWithoutTrailingSlashes'))
 app.use(require('./lib/middleware/codiMDVersion'))
 
 if (config.autoVersionCheck) {
+  checkVersion(app)
   app.use(versionCheckMiddleware)
 }
 

--- a/app.js
+++ b/app.js
@@ -25,6 +25,8 @@ var response = require('./lib/response')
 var models = require('./lib/models')
 var csp = require('./lib/csp')
 
+const { versionCheckMiddleware } = require('./lib/web/middleware/checkVersion')
+
 function createHttpServer () {
   if (config.useSSL) {
     const ca = (function () {
@@ -166,6 +168,10 @@ app.use(require('./lib/middleware/checkURIValid'))
 // redirect url without trailing slashes
 app.use(require('./lib/middleware/redirectWithoutTrailingSlashes'))
 app.use(require('./lib/middleware/codiMDVersion'))
+
+if (config.autoVersionCheck) {
+  app.use(versionCheckMiddleware)
+}
 
 // routes need sessions
 // template files

--- a/app.js
+++ b/app.js
@@ -206,6 +206,10 @@ app.locals.authProviders = {
   email: config.isEmailEnable,
   allowEmailRegister: config.allowEmailRegister
 }
+app.locals.versionInfo = {
+  latest: true,
+  versionItem: null
+}
 
 // Export/Import menu items
 app.locals.enableDropBoxSave = config.isDropboxEnable

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -178,5 +178,6 @@ module.exports = {
   //    Generated id:   "31-good-morning-my-friend---do-you-have-5"
   //    2nd appearance: "31-good-morning-my-friend---do-you-have-5-1"
   //    3rd appearance: "31-good-morning-my-friend---do-you-have-5-2"
-  linkifyHeaderStyle: 'keep-case'
+  linkifyHeaderStyle: 'keep-case',
+  autoVersionCheck: true
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -142,5 +142,6 @@ module.exports = {
   allowPDFExport: toBooleanConfig(process.env.CMD_ALLOW_PDF_EXPORT),
   openID: toBooleanConfig(process.env.CMD_OPENID),
   defaultUseHardbreak: toBooleanConfig(process.env.CMD_DEFAULT_USE_HARD_BREAK),
-  linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE
+  linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE,
+  autoVersionCheck: toBooleanConfig(process.env.CMD_AUTO_VERSION_CHECK)
 }

--- a/lib/web/middleware/checkVersion.js
+++ b/lib/web/middleware/checkVersion.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { promisify } = require('util')
+
+const request = require('request')
+
+const logger = require('../../logger')
+const config = require('../../config')
+
+let lastCheckAt
+let latest = true
+let versionItem = null
+
+const VERSION_CHECK_ENDPOINT = 'https://evangelion.codimd.dev/'
+const CHECK_TIMEOUT = 1000 * 60 * 60 * 24 // 1 day
+
+const rp = promisify(request)
+
+exports.versionCheckMiddleware = async function (req, res, next) {
+  if (lastCheckAt && (lastCheckAt + CHECK_TIMEOUT > Date.now())) {
+    return next()
+  }
+
+  // update lastCheckAt whether the check would fail or not
+  lastCheckAt = Date.now()
+
+  try {
+    const { statusCode, body: data } = await rp({
+      url: `${VERSION_CHECK_ENDPOINT}?v=${config.version}`,
+      method: 'GET',
+      json: true
+    })
+
+    if (statusCode !== 200 || data.status === 'error') {
+      logger.error('Version check failed.')
+      return next()
+    }
+
+    latest = data.latest
+    versionItem = latest ? null : data.versionItem
+
+    return next()
+  } catch (err) {
+    // ignore and skip version check
+    logger.error('Version check failed.')
+    logger.error(err)
+    return next()
+  }
+}
+
+exports.versionItem = versionItem
+exports.outdated = outdated

--- a/lib/web/middleware/checkVersion.js
+++ b/lib/web/middleware/checkVersion.js
@@ -14,9 +14,13 @@ const CHECK_TIMEOUT = 1000 * 60 * 60 * 24 // 1 day
 
 const rp = promisify(request)
 
-exports.versionCheckMiddleware = async function (req, res, next) {
+exports.checkVersion = checkVersion
+/**
+ * @param {Express.Application|Express.Request} ctx
+ */
+async function checkVersion (ctx) {
   if (lastCheckAt && (lastCheckAt + CHECK_TIMEOUT > Date.now())) {
-    return next()
+    return
   }
 
   // update lastCheckAt whether the check would fail or not
@@ -31,17 +35,36 @@ exports.versionCheckMiddleware = async function (req, res, next) {
 
     if (statusCode !== 200 || data.status === 'error') {
       logger.error('Version check failed.')
-      return next()
+      return
     }
 
-    req.app.locals.versionInfo.latest = data.latest
-    req.app.locals.versionInfo.versionItem = req.app.locals.latest ? null : data.versionItem
+    let locals = ctx.locals ? ctx.locals : ctx.app.locals
 
-    return next()
+    locals.versionInfo.latest = data.latest
+    locals.versionInfo.versionItem = data.latest ? null : data.versionItem
+
+    if (!data.latest) {
+      const { version, link } = data.versionItem
+
+      logger.warn(`Your CodiMD version is out of date! The latest version is ${version}. Please see what's new on ${link}.`)
+    }
+
+    return
   } catch (err) {
     // ignore and skip version check
     logger.error('Version check failed.')
     logger.error(err)
-    return next()
+
+    return
   }
+}
+
+exports.versionCheckMiddleware = function (req, res, next) {
+  checkVersion(req)
+    .then(() => {
+      next()
+    })
+    .catch((err) => {
+      next()
+    })
 }

--- a/lib/web/middleware/checkVersion.js
+++ b/lib/web/middleware/checkVersion.js
@@ -38,7 +38,7 @@ async function checkVersion (ctx) {
       return
     }
 
-    let locals = ctx.locals ? ctx.locals : ctx.app.locals
+    const locals = ctx.locals ? ctx.locals : ctx.app.locals
 
     locals.versionInfo.latest = data.latest
     locals.versionInfo.versionItem = data.latest ? null : data.versionItem
@@ -48,14 +48,10 @@ async function checkVersion (ctx) {
 
       logger.warn(`Your CodiMD version is out of date! The latest version is ${version}. Please see what's new on ${link}.`)
     }
-
-    return
   } catch (err) {
     // ignore and skip version check
     logger.error('Version check failed.')
     logger.error(err)
-
-    return
   }
 }
 
@@ -65,6 +61,7 @@ exports.versionCheckMiddleware = function (req, res, next) {
       next()
     })
     .catch((err) => {
+      logger.error(err)
       next()
     })
 }

--- a/lib/web/middleware/checkVersion.js
+++ b/lib/web/middleware/checkVersion.js
@@ -8,8 +8,6 @@ const logger = require('../../logger')
 const config = require('../../config')
 
 let lastCheckAt
-let latest = true
-let versionItem = null
 
 const VERSION_CHECK_ENDPOINT = 'https://evangelion.codimd.dev/'
 const CHECK_TIMEOUT = 1000 * 60 * 60 * 24 // 1 day
@@ -36,8 +34,8 @@ exports.versionCheckMiddleware = async function (req, res, next) {
       return next()
     }
 
-    latest = data.latest
-    versionItem = latest ? null : data.versionItem
+    req.app.locals.versionInfo.latest = data.latest
+    req.app.locals.versionInfo.versionItem = req.app.locals.latest ? null : data.versionItem
 
     return next()
   } catch (err) {
@@ -47,6 +45,3 @@ exports.versionCheckMiddleware = async function (req, res, next) {
     return next()
   }
 }
-
-exports.versionItem = versionItem
-exports.outdated = outdated


### PR DESCRIPTION
This PR implements a version checking functionality.

It would send the version number (e.g. `1.4.1`) to our version checking service (`evangelion.codimd.dev`) and log the result. Now it only does `console.warn` to let service admin know it's an outdated instance. For the future, we can add a more detailed UI for displaying such information.