### PR TITLE
Support multi-row and row span table syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11657,6 +11657,28 @@
       "resolved": "https://registry.npmjs.org/markdown-it-mathjax/-/markdown-it-mathjax-2.0.0.tgz",
       "integrity": "sha1-ritPTFxxmgP55HXGZPeyaFIx2ek="
     },
+    "markdown-it-multimd-table": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-multimd-table/-/markdown-it-multimd-table-4.0.1.tgz",
+      "integrity": "sha512-ZgRV8LlGz6JXTZ5zd82yCL8IVG5MRastMWxxrc6hQC8aC8kq/7zpp+ksBqVqcdTmTdabnkuSo/7h3SyKM31YCA==",
+      "requires": {
+        "markdown-it": "^8.4.2"
+      },
+      "dependencies": {
+        "markdown-it": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+          "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "entities": "~1.1.1",
+            "linkify-it": "^2.0.0",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
+      }
+    },
     "markdown-it-regexp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "markdown-it-ins": "~2.0.0",
     "markdown-it-mark": "~2.0.0",
     "markdown-it-mathjax": "~2.0.0",
+    "markdown-it-multimd-table": "^4.0.1",
     "markdown-it-regexp": "~0.4.0",
     "markdown-it-sub": "~1.0.0",
     "markdown-it-sup": "~1.0.0",

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1056,6 +1056,11 @@ md.use(require('markdown-it-mathjax')({
 }))
 md.use(require('markdown-it-imsize'))
 md.use(require('markdown-it-ruby'))
+md.use(require('markdown-it-multimd-table'), {
+  multiline: true,
+  rowspan: true,
+  headerless: false
+})
 
 window.emojify.setConfig({
   blacklist: {


### PR DESCRIPTION
This PR support two new table syntax, one is multi-row syntax that use `\` to merge multiple row into one row. another is row-span syntax that can merge multiple column into one colume (like html rowspan attribute)

1. multi-row syntax example 
```markdown
|   Markdown   | Rendered HTML |
|--------------|---------------|
|    *Italic*  | *Italic*      | \
|              |               |
|    - Item 1  | - Item 1      | \
|    - Item 2  | - Item 2      |
|    ```python | ```python       \
|    .1 + .2   | .1 + .2         \
|    ```       | ```           |
```

2. row span syntax
```
Stage | Direct Products | ATP Yields
----: | --------------: | ---------:
Glycolysis | 2 ATP ||
^^ | 2 NADH | 3--5 ATP |
Pyruvaye oxidation | 2 NADH | 5 ATP |
Citric acid cycle | 2 ATP ||
^^ | 6 NADH | 15 ATP |
^^ | 2 FADH2 | 3 ATP |
**30--32** ATP |||
[Net ATP yields per hexose]
```