### PR TITLE
fix: catch viz.js render async error and recreate Viz instance

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -31,7 +31,7 @@ require('prismjs/components/prism-gherkin')
 
 require('./lib/common/login')
 require('../vendor/md-toc')
-const viz = new window.Viz()
+let viz = new window.Viz()
 const plantumlEncoder = require('plantuml-encoder')
 
 const ui = getUIElements()
@@ -379,8 +379,13 @@ export function finishView (view) {
           $ele.addClass('graphviz')
           $value.children().unwrap()
         })
+        .catch(err => {
+          viz = new window.Viz()
+          $value.parent().append(`<div class="alert alert-warning">${escapeHTML(err)}</div>`)
+          console.warn(err)
+        })
     } catch (err) {
-      $value.unwrap()
+      viz = new window.Viz()
       $value.parent().append(`<div class="alert alert-warning">${escapeHTML(err)}</div>`)
       console.warn(err)
     }


### PR DESCRIPTION
This PR fixes #1374 

- viz.js return Promise since version 2.0.0 and we didn't catch the error properly
- on catching error, we should recreate Viz instance to clean up the error, see more: https://github.com/mdaines/viz.js/wiki/Caveats