### PR TITLE
Feature/upgrade reveal.js 3.9.2

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -71,7 +71,7 @@ function addInlineScriptExceptions (directives) {
   directives.scriptSrc.push(getCspNonce)
   // TODO: This is the SHA-256 hash of the inline script in build/reveal.js/plugins/notes/notes.html
   // Any more clean solution appreciated.
-  directives.scriptSrc.push('\'sha256-Lc+VnBdinzYTTAkFrIoUqdoA9EQFeS1AF9ybmF+LLfM=\'')
+  directives.scriptSrc.push('\'sha256-81acLZNZISnyGYZrSuoYhpzwDTTxi7vC1YM4uNxqWaM=\'')
 }
 
 function getCspNonce (req, res) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13086,9 +13086,9 @@
       }
     },
     "reveal.js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-3.7.0.tgz",
-      "integrity": "sha512-HTOTNhF5mQAw6fcsptk4oql/DEEUwTG0YHk/LzTNNx0/3IgvOQZqKzvlK/zNpqqKMLlhn1gH9Nvp+FFoc/e5/w=="
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-3.9.2.tgz",
+      "integrity": "sha512-Dvv2oA9FrtOHE2DWj5js8pMRfwq++Wmvsn1EyAdYLC80lBjTphns+tPsB652Bnvep9AVviuVS/b4XoVY9rXHLA=="
     },
     "rgb-regex": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "raphael": "~2.2.8",
     "readline-sync": "~1.4.7",
     "request": "~2.88.0",
-    "reveal.js": "~3.7.0",
+    "reveal.js": "~3.9.2",
     "scrypt": "~6.0.3",
     "select2": "~3.5.2-browserify",
     "sequelize": "5.21.3",

--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -348,7 +348,7 @@ stop
 > More information about **sequence diagrams** syntax [here](http://bramp.github.io/js-sequence-diagrams/).
 > More information about **flow charts** syntax [here](http://adrai.github.io/flowchart.js/).
 > More information about **graphviz** syntax [here](http://www.tonyballantyne.com/graphs.html)
-> More information about **mermaid** syntax [here](http://knsv.github.io/mermaid)
+> More information about **mermaid** syntax [here](http://mermaid-js.github.io/mermaid)
 > More information about **abc** syntax [here](http://abcnotation.com/learn)
 > More information about **plantuml** syntax [here](http://plantuml.com/index)
 > More information about **vega** syntax [here](https://vega.github.io/vega-lite/docs)

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -18,7 +18,7 @@
         <% if(useCDN) { %>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.7/css/fork-awesome.min.css" integrity="sha256-gsmEoJAws/Kd3CjuOQzLie5Q3yshhvmo7YNtBG7aaEY=" crossorigin="anonymous" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css" integrity="sha256-3iu9jgsy9TpTwXKb7bNQzqWekRX7pPK+2OLj3R922fo=" crossorigin="anonymous" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0/css/reveal.min.css" integrity="sha256-9+Wg2bcNeiOMGXOUNqBdceY2lAH/eCiTDcdzHhHIl48=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@3.9.2/css/reveal.min.css" integrity="sha256-h2NhWerL2k7KAzo6YqYMo1T5B6+QT2Bb/CprRV2aW20=" crossorigin="anonymous" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@hackmd/emojify.js@2.1.0/dist/css/basic/emojify.min.css" integrity="sha256-UOrvMOsSDSrW6szVLe8ZDZezBxh5IoIfgTwdNDgTjiU=" crossorigin="anonymous" />
         <%- include build/slide-header %>
         <%- include shared/polyfill %>
@@ -88,8 +88,7 @@
 
         <script src="<%= serverURL %>/js/mathjax-config-extra.js"></script>
         <% if(useCDN) { %>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0/lib/js/head.min.js" integrity="sha256-CTcwyen1cxIrm4hlqdxe0y7Hq6B0rpxAKLiXMD3dJv0=" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0/js/reveal.min.js" integrity="sha256-Xr6ZH+/kc7hDVReZLO5khBknteLqu5oen/xnSraXrVk=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/reveal.js@3.9.2/js/reveal.min.js" integrity="sha256-1fq1NvUmkMIWOBgIEzGFr0UUNuwWmOa29YqMkXnYlH4=" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.2/velocity.min.js" integrity="sha256-1HqoI76JGKA17K0C0s9K8L/iy8PAC43KVLt1hRD/Ojc=" crossorigin="anonymous" defer></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js" integrity="sha256-jnOjDTXIPqall8M0MyTSt98JetJuZ7Yu+1Jm7hLTF7U=" crossorigin="anonymous" defer></script>

--- a/test/csp.js
+++ b/test/csp.js
@@ -49,8 +49,10 @@ describe('Content security policies', function () {
     csp = mock.reRequire('../lib/csp')
 
     assert(!csp.computeDirectives().scriptSrc.includes('https://cdnjs.cloudflare.com'))
+    assert(!csp.computeDirectives().scriptSrc.includes('https://cdn.jsdelivr.net'))
     assert(!csp.computeDirectives().scriptSrc.includes('https://cdn.mathjax.org'))
     assert(!csp.computeDirectives().styleSrc.includes('https://cdnjs.cloudflare.com'))
+    assert(!csp.computeDirectives().styleSrc.includes('https://cdn.jsdelivr.net'))
     assert(!csp.computeDirectives().styleSrc.includes('https://fonts.googleapis.com'))
     assert(!csp.computeDirectives().fontSrc.includes('https://cdnjs.cloudflare.com'))
     assert(!csp.computeDirectives().fontSrc.includes('https://fonts.gstatic.com'))
@@ -119,6 +121,6 @@ describe('Content security policies', function () {
   it('Unchanged hash for reveal.js speaker notes plugin', function () {
     const hash = crypto.createHash('sha1')
     hash.update(fs.readFileSync(path.resolve(__dirname, '../node_modules/reveal.js/plugin/notes/notes.html'), 'utf8'), 'utf8')
-    assert.strictEqual(hash.digest('hex'), '471f3826880fac884a4a14faabc492bc854ae994')
+    assert.strictEqual(hash.digest('hex'), 'd5d872ae49b5db27f638b152e6e528837204d380')
   })
 })

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -364,7 +364,6 @@ module.exports = {
       'script-loader!vega',
       'script-loader!vega-lite',
       'script-loader!vega-embed',
-      'headjs',
       'expose-loader?Reveal!reveal.js',
       'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/slide.js')
@@ -391,7 +390,6 @@ module.exports = {
       'jquery-ui-resizable': path.join(__dirname, 'public/vendor/jquery-ui/jquery-ui.min.js'),
       'gist-embed': path.join(__dirname, 'node_modules/gist-embed/gist-embed.min.js'),
       'bootstrap-tooltip': path.join(__dirname, 'public/vendor/bootstrap/tooltip.min.js'),
-      'headjs': path.join(__dirname, 'node_modules/reveal.js/lib/js/head.min.js'),
       'reveal-markdown': path.join(__dirname, 'public/js/reveal-markdown.js'),
       abcjs: path.join(__dirname, 'public/vendor/abcjs_basic_3.1.1-min.js'),
       raphael: path.join(__dirname, 'node_modules/raphael/raphael.min.js'),


### PR DESCRIPTION
- upgrade reveal.js from 3.7.0 to 3.9.2
- remove head.js dependency after reveal.js 3.8.0
- update CSP nonce for speaker notes feature
- fix mermaid docs link in features.md