### PR TITLE
feat: upgrade markdown-it to 10.0.0 for supporting em in strong tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9121,15 +9121,22 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-9.0.1.tgz",
-      "integrity": "sha512-XC9dMBHg28Xi7y5dPuLjM61upIGPJG8AiHNHYqIaXER2KNnn7eKnM5/sF0ImNnyoV224Ogn9b1Pck8VH4k0bxw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~1.1.1",
+        "entities": "~2.0.0",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "markdown-it-abbr": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "list.js": "~1.5.0",
     "lodash": "~4.17.15",
     "lutim": "~1.0.2",
-    "markdown-it": "~9.0.1",
+    "markdown-it": "~10.0.0",
     "markdown-it-abbr": "~1.0.4",
     "markdown-it-container": "~2.0.0",
     "markdown-it-deflist": "~2.0.3",


### PR DESCRIPTION
- upgrade markdown-it from 9.0.1 to 10.0.0
    - Fix quadratic parse time for some combinations of pairs, #583. Algorithm is now similar to one in reference implementation.
    - support CommonMark spec 0.29

for example: ex***amp***le
https://github.com/markdown-it/markdown-it/commit/e519e6ac198221ace43685360647a3fce666df81
https://github.com/commonmark/commonmark-spec/commit/83ed53e12aa2e011b04474825bfb22a40682e4a0

Signed-off-by: Max Wu <jackymaxj@gmail.com>