### PR TITLE
fix: use validator.isURL to avoid regex catastrophic backtracking

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -9,6 +9,8 @@ import { saveAs } from 'file-saver'
 import escapeHTML from 'lodash/escape'
 import unescapeHTML from 'lodash/unescape'
 
+import isURL from 'validator/lib/isURL'
+
 import { stripTags } from '../../utils/string'
 
 import getUIElements from './lib/editor/ui-elements'
@@ -176,20 +178,6 @@ function slugifyWithUTF8 (text) {
   // slugify string to make it valid as an attribute
   newText = newText.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '')
   return newText
-}
-
-export function isValidURL (str) {
-  const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-  if (!pattern.test(str)) {
-    return false
-  } else {
-    return true
-  }
 }
 
 // parse meta
@@ -1300,7 +1288,7 @@ const pdfPlugin = new Plugin(
 
   (match, utils) => {
     const pdfurl = match[1]
-    if (!isValidURL(pdfurl)) return match[0]
+    if (!isURL(pdfurl)) return match[0]
     const div = $('<div class="pdf raw"></div>')
     div.attr('data-pdfurl', pdfurl)
     return div[0].outerHTML

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -9,6 +9,8 @@ import randomColor from 'randomcolor'
 import store from 'store'
 import hljs from 'highlight.js'
 
+import isURL from 'validator/lib/isURL'
+
 import _ from 'lodash'
 
 import wurl from 'wurl'
@@ -41,7 +43,6 @@ import {
   removeDOMEvents,
   finishView,
   generateToc,
-  isValidURL,
   md,
   parseMeta,
   postProcess,
@@ -1400,7 +1401,7 @@ $('#gistImportModalConfirm').click(function () {
   if (!gisturl) return
   $('#gistImportModal').modal('hide')
   $('#gistImportModalContent').val('')
-  if (!isValidURL(gisturl)) {
+  if (!isURL(gisturl)) {
     showMessageModal('<i class="fa fa-github"></i> Import from Gist', 'Not a valid URL :(', '', '', false)
   } else {
     var hostname = wurl('hostname', gisturl)
@@ -1534,7 +1535,7 @@ function replaceAll (data) {
 function importFromUrl (url) {
   // console.log(url);
   if (!url) return
-  if (!isValidURL(url)) {
+  if (!isURL(url)) {
     showMessageModal('<i class="fa fa-cloud-download"></i> Import from URL', 'Not a valid URL :(', '', '', false)
     return
   }


### PR DESCRIPTION
The validate URL function `isValidURL` was borrowed from: https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url/43467144

for example: `https://doc-12-34-ssa-view.111/asdfasdfasdfasdfqweqweqwe`
adding more characters to the URL will cause catastrophic backtracking and leads to UI freezing.

Signed-off-by: Max Wu <jackymaxj@gmail.com>