### PR TITLE
Disable HSTS IncludeSubdomain, to prevent unexpected behavior

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -14,7 +14,7 @@ module.exports = {
   hsts: {
     enable: true,
     maxAgeSeconds: 60 * 60 * 24 * 365,
-    includeSubdomains: true,
+    includeSubdomains: false,
     preload: true
   },
   csp: {


### PR DESCRIPTION
This is breaking change !!!
This PR change HSTS IncludeSubdomain setting to false.
In default setting, its will force subdomain use HSTS, but it's breaking the site that hosted in subdomain and didn't has SSL certificate.