### PR TITLE
Fix west longitude and south latitude not parsed correctly in geo map

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -450,7 +450,7 @@ export function finishView (view) {
 
     try {
       let position, zoom
-      if (content.match(/^[\d.,\s]+$/)) {
+      if (content.match(/^[-\d.,\s]+$/)) {
         const [lng, lat, zoo] = content.split(',').map(parseFloat)
         zoom = zoo
         position = [lat, lng]


### PR DESCRIPTION
This PR fixed geo-map not parsed west longitude and south latitude corrlectly (caused by negative number of longitude and latitude)