### PR TITLE
Allow inline markdown in spoiler summary syntax

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1124,7 +1124,7 @@ md.use(markdownitContainer, 'spoiler', {
       // opening tag
       const summary = m[1] && m[1].trim()
       if (summary) {
-        return `<details><summary>${md.utils.escapeHtml(summary)}</summary>\n`
+        return `<details><summary>${md.renderInline(summary)}</summary>\n`
       } else {
         return `<details>\n`
       }

--- a/public/js/lib/syncscroll.js
+++ b/public/js/lib/syncscroll.js
@@ -125,7 +125,7 @@ md.use(markdownitContainer, 'spoiler', {
       const partClass = `class="part raw" data-startline="${startline}" data-endline="${endline}"`
       const summary = m[1] && m[1].trim()
       if (summary) {
-        return `<details ${partClass}><summary>${md.utils.escapeHtml(summary)}</summary>\n`
+        return `<details ${partClass}><summary>${md.renderInline(summary)}</summary>\n`
       } else {
         return `<details ${partClass}>\n`
       }


### PR DESCRIPTION
You can use inline markdown in the spoiler summary syntax now:

![image](https://user-images.githubusercontent.com/4230968/76177359-ee849b00-61ee-11ea-80e8-003c8460e0cb.png)

```markdown
:::spoiler **click** me and [show](https://github.com/hackmdio/codimd) me the code
Hide me
:::
```