### PR TITLE
Support avatar for OAuth users

### DIFF
--- a/lib/auth/oauth2/strategy.js
+++ b/lib/auth/oauth2/strategy.js
@@ -7,6 +7,7 @@ function parseProfile (data) {
   const username = extractProfileAttribute(data, config.oauth2.userProfileUsernameAttr)
   const displayName = extractProfileAttribute(data, config.oauth2.userProfileDisplayNameAttr)
   const email = extractProfileAttribute(data, config.oauth2.userProfileEmailAttr)
+  const photo = extractProfileAttribute(data, config.oauth2.userProfilePhotoAttr)
 
   if (!username) {
     throw new Error('cannot fetch username: please set correct CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR')
@@ -16,7 +17,8 @@ function parseProfile (data) {
     id: username,
     username: username,
     displayName: displayName,
-    email: email
+    email: email,
+    photo: photo
   }
 }
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -99,6 +99,7 @@ module.exports = {
     userProfileUsernameAttr: 'username',
     userProfileDisplayNameAttr: 'displayName',
     userProfileEmailAttr: 'email',
+    userProfilePhotoAttr: 'photo',
     scope: 'email'
   },
   facebook: {

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -96,7 +96,8 @@ module.exports = {
     scope: process.env.CMD_OAUTH2_SCOPE,
     userProfileUsernameAttr: process.env.CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR,
     userProfileDisplayNameAttr: process.env.CMD_OAUTH2_USER_PROFILE_DISPLAY_NAME_ATTR,
-    userProfileEmailAttr: process.env.CMD_OAUTH2_USER_PROFILE_EMAIL_ATTR
+    userProfileEmailAttr: process.env.CMD_OAUTH2_USER_PROFILE_EMAIL_ATTR,
+    userProfilePhotoAttr: process.env.CMD_OAUTH2_USER_PROFILE_PHOTO_ATTR
   },
   dropbox: {
     clientID: process.env.CMD_DROPBOX_CLIENTID,

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -140,6 +140,10 @@ module.exports = function (sequelize, DataTypes) {
       case 'saml':
         photo = generateAvatarURL(profile.username, profile.emails[0], bigger)
         break
+      case 'oauth2':
+        photo = profile.photo
+        if (!photo) photo = generateAvatarURL(profile.username, profile.email, bigger)
+        break
     }
     return photo
   }


### PR DESCRIPTION
Enable OAuth users to have avatars from a field in `userProfileURL` or Gravatar.