### PR TITLE
Improve version checker behavior

### DIFF
--- a/lib/web/middleware/checkVersion.js
+++ b/lib/web/middleware/checkVersion.js
@@ -31,7 +31,7 @@ async function checkVersion (ctx) {
       url: `${VERSION_CHECK_ENDPOINT}?v=${config.version}`,
       method: 'GET',
       json: true,
-      timeout: 1000
+      timeout: 3000
     })
 
     if (statusCode !== 200 || data.status === 'error') {

--- a/lib/web/middleware/checkVersion.js
+++ b/lib/web/middleware/checkVersion.js
@@ -30,11 +30,12 @@ async function checkVersion (ctx) {
     const { statusCode, body: data } = await rp({
       url: `${VERSION_CHECK_ENDPOINT}?v=${config.version}`,
       method: 'GET',
-      json: true
+      json: true,
+      timeout: 1000
     })
 
     if (statusCode !== 200 || data.status === 'error') {
-      logger.error('Version check failed.')
+      logger.warn('Version check failed.')
       return
     }
 
@@ -46,12 +47,12 @@ async function checkVersion (ctx) {
     if (!data.latest) {
       const { version, link } = data.versionItem
 
-      logger.warn(`Your CodiMD version is out of date! The latest version is ${version}. Please see what's new on ${link}.`)
+      logger.info(`Your CodiMD version is out of date! The latest version is ${version}. Please see what's new on ${link}.`)
     }
   } catch (err) {
     // ignore and skip version check
-    logger.error('Version check failed.')
-    logger.error(err)
+    logger.warn('Version check failed.')
+    logger.warn(err)
   }
 }
 


### PR DESCRIPTION
This PR' is to improve version checker behavior.

1. setup timeout to 1000ms: if server's network is unstable, may cause response too slow.
2. change logger type from warn --> info, error --> warn