### PR TITLE
Fix check for creating free url notes

### DIFF
--- a/lib/note/index.js
+++ b/lib/note/index.js
@@ -34,7 +34,7 @@ async function getNoteById (noteId, { includeUser } = { includeUser: false }) {
 }
 
 async function createNote (userId, noteAlias) {
-  if (!config.allowAnonymous && !!userId) {
+  if (!config.allowAnonymous && !userId) {
     throw new Error('can not create note')
   }
 


### PR DESCRIPTION
Current check prevents creation of notes when allowAnonymous is disabled and user is logged in