### PR TITLE
Fix check for creating free url notes

### DIFF
--- a/lib/note/index.js
+++ b/lib/note/index.js
@@ -34,7 +34,9 @@ async function getNoteById (noteId, { includeUser } = { includeUser: false }) {
 }
 
 async function createNote (userId, noteAlias) {
-  if (!config.allowAnonymous && !userId) {
+  // The following check will throw an error if:
+  // config.allowAnonymous is False OR userId is not set
+  if (!config.allowAnonymous || !userId) {
     throw new Error('can not create note')
   }
 

--- a/lib/note/index.js
+++ b/lib/note/index.js
@@ -36,7 +36,7 @@ async function getNoteById (noteId, { includeUser } = { includeUser: false }) {
 async function createNote (userId, noteAlias) {
   // The following check will throw an error if:
   // config.allowAnonymous is False OR userId is not set
-  if (!config.allowAnonymous || !userId) {
+  if !(config.allowAnonymous || userId) {
     throw new Error('can not create note')
   }
 


### PR DESCRIPTION
The current check requires that both `config.allowAnonymous` is true,
and a user is logged in. This change modifies the check to allow either
of these to be true, allowing anonymous access OR logged in access
when creating free url notes

Signed-off-by: Chris MacNaughton <chmacnaughton@gmail.com>