### PR TITLE
Support brace wrapped param in fence lang

### DIFF
--- a/public/js/lib/markdown/utils.js
+++ b/public/js/lib/markdown/utils.js
@@ -1,0 +1,53 @@
+export function parseFenceCodeParams (lang) {
+  const attrMatch = lang.match(/{(.*)}/)
+  const params = {}
+  if (attrMatch && attrMatch.length >= 2) {
+    const attrs = attrMatch[1]
+    const paraMatch = attrs.match(/([#.](\S+?)\s)|((\S+?)\s*=\s*("(.+?)"|'(.+?)'|\[[^\]]*\]|\{[}]*\}|(\S+)))/g)
+    paraMatch && paraMatch.forEach(param => {
+      param = param.trim()
+      if (param[0] === '#') {
+        params['id'] = param.slice(1)
+      } else if (param[0] === '.') {
+        if (params['class']) params['class'] = []
+        params['class'] = params['class'].concat(param.slice(1))
+      } else {
+        const offset = param.indexOf('=')
+        const id = param.substring(0, offset).trim().toLowerCase()
+        let val = param.substring(offset + 1).trim()
+        const valStart = val[0]
+        const valEnd = val[val.length - 1]
+        if (['"', "'"].indexOf(valStart) !== -1 && ['"', "'"].indexOf(valEnd) !== -1 && valStart === valEnd) {
+          val = val.substring(1, val.length - 1)
+        }
+        if (id === 'class') {
+          if (params['class']) params['class'] = []
+          params['class'] = params['class'].concat(val)
+        } else {
+          params[id] = val
+        }
+      }
+    })
+  }
+  return params
+}
+
+export function serializeParamToAttribute (params) {
+  if (Object.getOwnPropertyNames(params).length === 0) {
+    return ''
+  } else {
+    return ` data-params="${escape(JSON.stringify(params))}"`
+  }
+}
+
+/**
+ * @param {HTMLElement} elem
+ */
+export function deserializeParamAttributeFromElement (elem) {
+  const params = elem.getAttribute('data-params')
+  if (params) {
+    return JSON.parse(unescape(params))
+  } else {
+    return {}
+  }
+}

--- a/public/js/lib/syncscroll.js
+++ b/public/js/lib/syncscroll.js
@@ -73,7 +73,7 @@ md.renderer.rules.fence = (tokens, idx, options, env, self) => {
   }
 
   if (options.highlight) {
-    highlighted = options.highlight(token.content, langName) || md.utils.escapeHtml(token.content)
+    highlighted = options.highlight(token.content, info) || md.utils.escapeHtml(token.content)
   } else {
     highlighted = md.utils.escapeHtml(token.content)
   }


### PR DESCRIPTION
Now we support supply additional params in fence code language like:

~~~md
```fretboard {title="horizontal, 5 frets" type="h6 noNut"}
```
~~~

In post render functions, we can now use:

```diff
  fretboard.each((key, value) => {
+	const params = deserializeParamAttributeFromElement(value)
+   assert.true(params.title === "horizontal, 5 frets")
```

FYI @birdca