### PR TITLE
Fix GitHub's avatar URL

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -115,10 +115,11 @@ module.exports = function (sequelize, DataTypes) {
         else photo += '?size=bigger'
         break
       case 'github':
-        if (profile.photos && profile.photos[0]) photo = profile.photos[0].value.replace('?', '')
-        else photo = 'https://avatars.githubusercontent.com/u/' + profile.id
-        if (bigger) photo += '?s=400'
-        else photo += '?s=96'
+        const photoURL = new URL(profile.photos && profile.photos[0]
+          ? profile.photos[0].value
+          : `https://avatars.githubusercontent.com/u/${profile.id}`)
+        photoURL.searchParams.set('s', bigger ? 400 : 96)
+        photo = photoURL.toString()
         break
       case 'gitlab':
         photo = profile.avatarUrl


### PR DESCRIPTION
## What

At the moment, the URL is being composed and modified with the use of
string composition.

This causes issues, if the URL returned by GitHub slightly differs from
the time developer initially had a look into it.

In our case, the URL from GitHub has two query parameters in it, whilst
the codebase only expected one.

This change will take all of these parameters and only set the one we
care about, whilst leaving others intact and carry on with the full URL.

Fixes #1489

## How to review

- Run locally with GitHub OAuth enabled
- Login with GitHub
- See your avatar displayed properly
- *optionally* Follow the same steps on the `develop` branch to see difference