### PR TITLE
Use array for tags when available (close #1496)

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -367,8 +367,13 @@ module.exports = function (sequelize, DataTypes) {
   Note.extractNoteTags = function (meta, $) {
     var tags = []
     var rawtags = []
+    var metaTags
     if (meta.tags && (typeof meta.tags === 'string' || typeof meta.tags === 'number')) {
-      var metaTags = ('' + meta.tags).split(',')
+      metaTags = ('' + meta.tags).split(',')
+    } else if (meta.tags && (Array.isArray(meta.tags))) {
+      metaTags = meta.tags
+    }
+    if (metaTags) {
       for (let i = 0; i < metaTags.length; i++) {
         var text = metaTags[i].trim()
         if (text) rawtags.push(text)

--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -129,6 +129,13 @@ module.exports = function (sequelize, DataTypes) {
             return resolve(note)
           })
         })
+      },
+      afterUpdate: function(note, options, callback) {
+        const filePath = path.join(config.docsPath, note.alias + '.md')
+        if (Note.checkFileExist(filePath)) {
+          // if doc in filesystem, write content to file
+          Note.writeNoteToFilesystem(note, filePath);
+        }
       }
     }
   })
@@ -587,6 +594,15 @@ module.exports = function (sequelize, DataTypes) {
       }
     }
     return operations
+  }
+  Note.writeNoteToFilesystem = function (note, filePath) {
+    try {
+      fs.writeFileSync(filePath, note.content, 'utf8')
+      return true
+    } catch(err) {
+      logger.warn(err)
+      return false
+    }
   }
 
   return Note


### PR DESCRIPTION
This patch introduces metadata tags in array format.

Metadata tags can be done by either using strings (like before):

```
---
tags: tag1, tag2, tag3
---
```

And, with this patch, also using arrays, in any YAML supported format:

```
---
tags:
  - tag1
  - tag2
  - tag3
---
```

```
---
tags: [tag1, tag2, tag3]
---
```

This will make it more compatible with other software using structured types in the metadata section (I use CodiMD with other markdown software).