### PR TITLE
Write note to filesystem if file exists

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -129,6 +129,13 @@ module.exports = function (sequelize, DataTypes) {
             return resolve(note)
           })
         })
+      },
+      afterUpdate: function (note, options, callback) {
+        const filePath = path.join(config.docsPath, note.alias + '.md')
+        if (Note.checkFileExist(filePath)) {
+          // if doc in filesystem, write content to file
+          Note.writeNoteToFilesystem(note, filePath)
+        }
       }
     }
   })
@@ -582,6 +589,15 @@ module.exports = function (sequelize, DataTypes) {
       }
     }
     return operations
+  }
+  Note.writeNoteToFilesystem = function (note, filePath) {
+    try {
+      fs.writeFileSync(filePath, note.content, 'utf8')
+      return true
+    } catch (err) {
+      logger.warn(err)
+      return false
+    }
   }
 
   return Note


### PR DESCRIPTION
This patch writes note content back to the filesystem if a file exists in the public docs path. This can be a first step towards the real objective of #90 maybe?

Please note that this doesn't address the fact that notes loaded from docsPath are set with a null user owner ID so they are not actually editable. You need to update the row in the database for that. I believe that part should be addressed in another way (I was thinking something like per-user docsPath)