### PR TITLE
Use array for tags when available (close #1496)

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -367,8 +367,13 @@ module.exports = function (sequelize, DataTypes) {
   Note.extractNoteTags = function (meta, $) {
     var tags = []
     var rawtags = []
+    var metaTags
     if (meta.tags && (typeof meta.tags === 'string' || typeof meta.tags === 'number')) {
-      var metaTags = ('' + meta.tags).split(',')
+      metaTags = ('' + meta.tags).split(',')
+    } else if (meta.tags && (Array.isArray(meta.tags))) {
+      metaTags = meta.tags
+    }
+    if (metaTags) {
       for (let i = 0; i < metaTags.length; i++) {
         var text = metaTags[i].trim()
         if (text) rawtags.push(text)


### PR DESCRIPTION
> Recreating on a dedicated branch. Deprecates #1501

This patch introduces metadata tags in array format.

Metadata tags can be done by either using strings (like before):

```
---
tags: tag1, tag2, tag3
---
```

And, with this patch, also using arrays, in any YAML supported format:

```
---
tags:
  - tag1
  - tag2
  - tag3
---
```

```
---
tags: [tag1, tag2, tag3]
---
```

This will make it more compatible with other software using structured types in the metadata section (I use CodiMD with other markdown software).