### PR TITLE
fix: add state parameter for oauth2

### DIFF
--- a/lib/auth/oauth2/index.js
+++ b/lib/auth/oauth2/index.js
@@ -16,6 +16,7 @@ passport.use(new OAuth2CustomStrategy({
   clientSecret: config.oauth2.clientSecret,
   callbackURL: config.serverURL + '/auth/oauth2/callback',
   userProfileURL: config.oauth2.userProfileURL,
+  state: config.oauth2.state,
   scope: config.oauth2.scope
 }, passportGeneralCallback))
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -100,6 +100,7 @@ module.exports = {
     userProfileDisplayNameAttr: 'displayName',
     userProfileEmailAttr: 'email',
     userProfilePhotoAttr: 'photo',
+    state: true,
     scope: 'email'
   },
   facebook: {

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -94,6 +94,7 @@ module.exports = {
     tokenURL: process.env.CMD_OAUTH2_TOKEN_URL,
     userProfileURL: process.env.CMD_OAUTH2_USER_PROFILE_URL,
     scope: process.env.CMD_OAUTH2_SCOPE,
+    state: process.env.CMD_OAUTH2_STATE,
     userProfileUsernameAttr: process.env.CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR,
     userProfileDisplayNameAttr: process.env.CMD_OAUTH2_USER_PROFILE_DISPLAY_NAME_ATTR,
     userProfileEmailAttr: process.env.CMD_OAUTH2_USER_PROFILE_EMAIL_ATTR,


### PR DESCRIPTION
state parameter is recommended with oauth2 authentification to mitigate CSRF attacks (see [auth0 doc](https://auth0.com/docs/protocols/oauth2/oauth-state)).
[hydra](https://www.ory.sh/hydra) will throw the following error message if state is missing:

```
  description="The state is missing or has less than 8 characters and is therefore considered too weak" error=invalid_state hint="Request
 parameter \"state\" must be at least be 8 characters long to ensure sufficient entropy."
```

closes #1511 