### PR TITLE
Fix getStatus caused "TypeError: Converting circular structure to JSON"

### DIFF
--- a/lib/realtime/realtime.js
+++ b/lib/realtime/realtime.js
@@ -298,10 +298,12 @@ function getStatus () {
           }
         })
         .catch(function (err) {
-          return logger.error('count user failed: ' + err)
+          logger.error('count user failed: ' + err)
+          return Promise.reject(new Error('count user failed: ' + err))
         })
     }).catch(function (err) {
-      return logger.error('count note failed: ' + err)
+      logger.error('count note failed: ' + err)
+      return Promise.reject(new Error('count note failed: ' + err))
     })
 }
 
@@ -772,8 +774,7 @@ function queueForConnect (socket) {
           const noteId = socket.noteId
           logger.info('SERVER connected a client to [' + noteId + ']:')
           logger.info(JSON.stringify(user))
-          // logger.info(notes);
-          getStatus(function (data) {
+          getStatus().then(function (data) {
             logger.info(JSON.stringify(data))
           })
         }

--- a/lib/status/index.js
+++ b/lib/status/index.js
@@ -4,14 +4,19 @@ const realtime = require('../realtime/realtime')
 const config = require('../config')
 
 exports.getStatus = async (req, res) => {
-  const data = await realtime.getStatus()
-
   res.set({
     'Cache-Control': 'private', // only cache by client
     'X-Robots-Tag': 'noindex, nofollow', // prevent crawling
     'Content-Type': 'application/json'
   })
-  res.send(data)
+
+  try {
+    const data = await realtime.getStatus()
+    res.send(data)
+  } catch (e) {
+    console.error(e)
+    res.status(500).send(e.toString())
+  }
 }
 
 exports.getMetrics = async (req, res) => {


### PR DESCRIPTION
Fixed #1516

The getStatus function will return logger object when app can't connect to database. This behavior caused /status throw "TypeError: Converting circular structure to JSON".

This PR fixed the getStatus function, reject promise when error occurs. And return status code 500 to indicate that server status is not fine.