### PR TITLE
Change to use nodejs 10.20.1

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,4 +1,4 @@
-FROM hackmdio/buildpack:1.0.4 as BUILD
+FROM hackmdio/buildpack:node-10-0baafb79 as BUILD
 
 COPY --chown=hackmd:hackmd . .
 
@@ -12,11 +12,14 @@ RUN set -xe && \
     rm -rf .git .gitignore .travis.yml .dockerignore .editorconfig .babelrc .mailmap .sequelizerc.example \
         test docs contribute \
         package-lock.json webpack.prod.js webpack.htmlexport.js webpack.dev.js webpack.common.js \
-        config.json.example README.md CONTRIBUTING.md AUTHORS
+        config.json.example README.md CONTRIBUTING.md AUTHORS node_modules
 
-FROM hackmdio/runtime:1.0.6
+ARG RUNTIME=hackmdio/runtime:node-10-0baafb79
+
+FROM hackmdio/runtime:node-10-0baafb79
 USER hackmd
 WORKDIR /home/hackmd/app
 COPY --chown=1500:1500 --from=BUILD /home/hackmd/app .
+RUN npm install --production && npm cache clean --force && rm -rf /tmp/{core-js-banners,phantomjs}
 EXPOSE 3000
 ENTRYPOINT ["/home/hackmd/app/docker-entrypoint.sh"]

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,3 +1,5 @@
+ARG RUNTIME
+
 FROM hackmdio/buildpack:node-10-0baafb79 as BUILD
 
 COPY --chown=hackmd:hackmd . .
@@ -14,9 +16,7 @@ RUN set -xe && \
         package-lock.json webpack.prod.js webpack.htmlexport.js webpack.dev.js webpack.common.js \
         config.json.example README.md CONTRIBUTING.md AUTHORS node_modules
 
-ARG RUNTIME=hackmdio/runtime:node-10-0baafb79
-
-FROM hackmdio/runtime:node-10-0baafb79
+FROM $RUNTIME
 USER hackmd
 WORKDIR /home/hackmd/app
 COPY --chown=1500:1500 --from=BUILD /home/hackmd/app .

--- a/deployments/build.sh
+++ b/deployments/build.sh
@@ -2,4 +2,12 @@
 
 CURRENT_DIR=$(dirname "$BASH_SOURCE")
 
-docker build -t hackmdio/codimd -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."
+GIT_SHA1="$(git rev-parse HEAD)"
+GIT_SHORT_ID="${SHA1:0:8}"
+GIT_TAG=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+
+DOCKER_TAG="${GIT_TAG:-$GIT_SHORT_ID}"
+
+docker build -t "hackmdio/codimd:$DOCKER_TAG" -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."
+
+docker build --build-arg RUNTIME=node-10-cjk-0baafb79 -t "hackmdio/codimd:$DOCKER_TAG-cjk" -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."

--- a/deployments/build.sh
+++ b/deployments/build.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+set -x
+
 CURRENT_DIR=$(dirname "$BASH_SOURCE")
 
 GIT_SHA1="$(git rev-parse HEAD)"
-GIT_SHORT_ID="${SHA1:0:8}"
-GIT_TAG=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+GIT_SHORT_ID="${GIT_SHA1:0:8}"
+GIT_TAG=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2>/dev/null || echo "")
 
 DOCKER_TAG="${GIT_TAG:-$GIT_SHORT_ID}"
 
-docker build -t "hackmdio/codimd:$DOCKER_TAG" -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."
+docker build --build-arg RUNTIME=hackmdio/runtime:node-10-0baafb79 -t "hackmdio/hackmd:$DOCKER_TAG" -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."
 
-docker build --build-arg RUNTIME=node-10-cjk-0baafb79 -t "hackmdio/codimd:$DOCKER_TAG-cjk" -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."
+docker build --build-arg RUNTIME=hackmdio/runtime:node-10-cjk-0baafb79 -t "hackmdio/hackmd:$DOCKER_TAG-cjk" -f "$CURRENT_DIR/Dockerfile" "$CURRENT_DIR/.."


### PR DESCRIPTION

1. upgrade nodejs version to 10.20.1
2. reduce docker images size from 1.8G to 800MB
3. separate fonts, introducing new image tag postfix `-cjk`. If you need export markdown to pdf with CJK fonts, please use the image that with psotfix `-cjk`
