### PR TITLE
chore: change image version to 2.1.0 in docker-compose example

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -10,8 +10,11 @@ services:
       - "database-data:/var/lib/postgresql/data"
     restart: always
   codimd:
-    # you can use image or custom build below
-    image: nabo.codimd.dev/hackmdio/hackmd:2.0.0
+    # you can use image or custom build below,
+    # if you need CJK character with exported PDF files,
+    # please change the image tag with `cjk` postfix version
+    image: nabo.codimd.dev/hackmdio/hackmd:2.1.0
+    # image: nabo.codimd.dev/hackmdio/hackmd:2.1.0-cjk
     # build:
     #   context: ..
     #   dockerfile: ./deployments/Dockerfile


### PR DESCRIPTION
This PR change the docker image version to 2.1.0 in docker-compose.yml file.