### PR TITLE
Typo Fix

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -85,7 +85,7 @@
 	"Image": "Image",
 	"Code": "Code",
 	"Externals": "Externals",
-	"This is a alert area.": "This is an alert area.",
+	"This is an alert area.": "This is an alert area.",
 	"Revert": "Revert",
 	"Import from clipboard": "Import from clipboard",
 	"Paste your markdown or webpage here...": "Paste your markdown or webpage here…",


### PR DESCRIPTION
a alert --> an alert

Small typo, but it also appears on the English "Help" page.

