### PR TITLE
fix: improve image upload to filesystem may caused app crash

### DIFF
--- a/lib/imageRouter/filesystem.js
+++ b/lib/imageRouter/filesystem.js
@@ -1,9 +1,38 @@
 'use strict'
+
+const crypto = require('crypto')
+const fs = require('fs')
 const URL = require('url').URL
 const path = require('path')
 
 const config = require('../config')
 const logger = require('../logger')
+
+/**
+ * generate a random filename for uploaded image
+ */
+function randomFilename () {
+  const buf = crypto.randomBytes(16)
+  return `upload_${buf.toString('hex')}`
+}
+
+/**
+ * pick a filename not exist in filesystem
+ * maximum attempt 5 times
+ */
+function pickFilename (defaultFilename) {
+  let retryCounter = 5
+  let filename = defaultFilename
+  const extname = path.extname(defaultFilename)
+  while (retryCounter-- > 0) {
+    if (fs.existsSync(path.join(config.uploadsPath, filename))) {
+      filename = `${randomFilename()}${extname}`
+      continue
+    }
+    return filename
+  }
+  throw new Error('file exists.')
+}
 
 exports.uploadImage = function (imagePath, callback) {
   if (!imagePath || typeof imagePath !== 'string') {
@@ -16,11 +45,24 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
+  let filename = path.basename(imagePath)
+  try {
+    filename = pickFilename(path.basename(imagePath))
+  } catch (e) {
+    return callback(e, null)
+  }
+
+  try {
+    fs.copyFileSync(imagePath, path.join(config.uploadsPath, filename))
+  } catch (e) {
+    return callback(e, null)
+  }
+
   let url
   try {
-    url = (new URL(path.basename(imagePath), config.serverURL + '/uploads/')).href
+    url = (new URL(filename, config.serverURL + '/uploads/')).href
   } catch (e) {
-    url = config.serverURL + '/uploads/' + path.basename(imagePath)
+    url = config.serverURL + '/uploads/' + filename
   }
 
   callback(null, url)

--- a/lib/imageRouter/index.js
+++ b/lib/imageRouter/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const Router = require('express').Router
 const formidable = require('formidable')
 
@@ -15,10 +16,6 @@ imageRouter.post('/uploadimage', function (req, res) {
 
   form.keepExtensions = true
 
-  if (config.imageUploadType === 'filesystem') {
-    form.uploadDir = config.uploadsPath
-  }
-
   form.parse(req, function (err, fields, files) {
     if (err || !files.image || !files.image.path) {
       response.errorForbidden(req, res)
@@ -29,6 +26,8 @@ imageRouter.post('/uploadimage', function (req, res) {
 
       const uploadProvider = require('./' + config.imageUploadType)
       uploadProvider.uploadImage(files.image.path, function (err, url) {
+        // remove temporary upload file, and ignore any error
+        fs.unlink(files.image.path, () => {})
         if (err !== null) {
           logger.error(err)
           return res.status(500).end('upload image error')


### PR DESCRIPTION
This PR fixes users using filesystem as image storage and not setup proper permission may caused application crash.

1. always uploads file to os temporary path (formidable library default behavior)
2. In filesystem image upload module, move temp file into upload folder and if has any problem, return error properly.