### PR TITLE
Make editor can scroll over lines

### DIFF
--- a/public/js/lib/editor/ui-elements.js
+++ b/public/js/lib/editor/ui-elements.js
@@ -70,6 +70,9 @@ export const getUIElements = () => ({
     codemirrorSizerInner: $(
       '.ui-edit-area .CodeMirror .CodeMirror-sizer > div'
     ),
+    codemirrorLines: $(
+      '.ui-edit-area .CodeMirror .CodeMirror-lines'
+    ),
     markdown: $('.ui-view-area .markdown-body'),
     resize: {
       handle: $('.ui-resizable-handle'),


### PR DESCRIPTION
Update to make editor have extra scroll padding in the bottom that can scroll over editor lines (or say scroll past end) and leave only one line on top of the editor.

This solves #617 #1207 