### PR TITLE
Set TOC depth freely for every note by using YAML metadata or an option within `[toc]`

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -188,5 +188,6 @@ module.exports = {
   //    2nd appearance: "31-good-morning-my-friend---do-you-have-5-1"
   //    3rd appearance: "31-good-morning-my-friend---do-you-have-5-2"
   linkifyHeaderStyle: 'keep-case',
-  autoVersionCheck: true
+  autoVersionCheck: true,
+  defaultTocDepth: 3
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -148,5 +148,5 @@ module.exports = {
   defaultUseHardbreak: toBooleanConfig(process.env.CMD_DEFAULT_USE_HARD_BREAK),
   linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE,
   autoVersionCheck: toBooleanConfig(process.env.CMD_AUTO_VERSION_CHECK),
-  defaultTocDepth: toIntegerConfig(process.env.CMD_DEFAULT_TOC_DEPTH, 3)
+  defaultTocDepth: toIntegerConfig(process.env.CMD_DEFAULT_TOC_DEPTH)
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -148,5 +148,5 @@ module.exports = {
   defaultUseHardbreak: toBooleanConfig(process.env.CMD_DEFAULT_USE_HARD_BREAK),
   linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE,
   autoVersionCheck: toBooleanConfig(process.env.CMD_AUTO_VERSION_CHECK),
-  defaultTocDepth: toIntegerConfig(process.env.CMD_DEFAULT_TOC_DEPTH)
+  defaultTocDepth: toIntegerConfig(process.env.CMD_DEFAULT_TOC_DEPTH, 3)
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -147,5 +147,6 @@ module.exports = {
   openID: toBooleanConfig(process.env.CMD_OPENID),
   defaultUseHardbreak: toBooleanConfig(process.env.CMD_DEFAULT_USE_HARD_BREAK),
   linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE,
-  autoVersionCheck: toBooleanConfig(process.env.CMD_AUTO_VERSION_CHECK)
+  autoVersionCheck: toBooleanConfig(process.env.CMD_AUTO_VERSION_CHECK),
+  defaultTocDepth: toIntegerConfig(process.env.CMD_DEFAULT_TOC_DEPTH)
 }

--- a/lib/status/index.js
+++ b/lib/status/index.js
@@ -41,7 +41,8 @@ exports.getConfig = (req, res) => {
     allowedUploadMimeTypes: config.allowedUploadMimeTypes,
     defaultUseHardbreak: config.defaultUseHardbreak,
     linkifyHeaderStyle: config.linkifyHeaderStyle,
-    useCDN: config.useCDN
+    useCDN: config.useCDN,
+    defaultTocDepth: config.defaultTocDepth
   }
   res.set({
     'Cache-Control': 'private', // only cache by client

--- a/public/css/extra.css
+++ b/public/css/extra.css
@@ -253,6 +253,32 @@
     padding-right: 40px;
 }
 
+.ui-toc-dropdown .nav .nav>li>ul>li>ul>li>a {
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 50px;
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>ul>li>a {
+  padding-right: 50px;
+}
+
+.ui-toc-dropdown .nav .nav>li>ul>li>ul>li>ul>li>a {
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 60px;
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>ul>li>ul>li>a {
+  padding-right: 60px;
+}
+
+
+
 .ui-toc-dropdown .nav .nav>li>a:focus,.ui-toc-dropdown .nav .nav>li>a:hover {
     padding-left: 29px;
 }
@@ -267,6 +293,22 @@
 
 .ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>a:focus,.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>a:hover {
     padding-right: 39px;
+}
+
+.ui-toc-dropdown .nav .nav>li>ul>li>ul>li>a:focus,.ui-toc-dropdown .nav .nav>li>ul>li>ul>li>a:hover {
+  padding-left: 49px;
+}
+
+.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>ul>li>a:focus,.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>ul>li>a:hover {
+  padding-right: 49px;
+}
+
+.ui-toc-dropdown .nav .nav>li>ul>li>ul>li>ul>li>a:focus,.ui-toc-dropdown .nav .nav>li>ul>li>ul>li>ul>li>a:hover {
+  padding-left: 59px;
+}
+
+.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>ul>li>ul>li>a:focus,.ui-toc-dropdown[dir='rtl'] .nav .nav>li>ul>li>ul>li>ul>li>a:hover {
+  padding-right: 59px;
 }
 
 .ui-toc-dropdown .nav .nav>.active:focus>a,.ui-toc-dropdown .nav .nav>.active:hover>a,.ui-toc-dropdown .nav .nav>.active>a {
@@ -285,6 +327,24 @@
 
 .ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active:focus>a,.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active:hover>a,.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active>a {
     padding-right: 38px;
+}
+
+.ui-toc-dropdown .nav .nav>.active>.nav>.active>.nav>.active:focus>a,.ui-toc-dropdown .nav .nav>.active>.nav>.active>.nav>.active:hover>a,.ui-toc-dropdown .nav .nav>.active>.nav>.active>.nav>.active>a {
+  padding-left: 48px;
+  font-weight: 500;
+}
+
+.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active>.nav>.active:focus>a,.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active>.nav>.active:hover>a,.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.active>.nav>.nav>.active>a {
+  padding-right: 48px;
+}
+
+.ui-toc-dropdown .nav .nav>.active>.nav>.active>.nav>.active>.nav>.active:focus>a,.ui-toc-dropdown .nav .nav>.active>.nav>.active>.nav>.active>.nav>.active:hover>a,.ui-toc-dropdown .nav .nav>.active>.nav>.active>.nav>.active>.nav>.active>a {
+  padding-left: 58px;
+  font-weight: 500;
+}
+
+.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active>.nav>.active>.nav>.active:focus>a,.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.nav>.active>.nav>.active>.nav>.active:hover>a,.ui-toc-dropdown[dir='rtl'] .nav .nav>.active>.active>.nav>.nav>.active>.nav>.active>a {
+  padding-right: 58px;
 }
 
 /* support japanese font */

--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -82,7 +82,8 @@ View
 ## Table of Contents:
 You can look at the bottom right section of the view area, there is a _ToC_ button <i class="fa fa-bars"></i>.
 Pressing that button will show you a current _Table of Contents_, and will highlight which section you're at.
-ToCs support up to **three header levels**.
+ToCs support up to **five header levels**, the **default** is **set to three**. The maxLevel can be set for each note by using 
+[YAML Metadata](./yaml-metadata)
 
 ## Permalink
 Every header will automatically add a permalink on the right side.
@@ -133,11 +134,18 @@ You can provide advanced note information to set the browser behavior (visit abo
 - GA: set to use Google Analytics
 - disqus: set to use Disqus
 - slideOptions: setup slide mode options
+- toc: set options of the Table of Contents.
 
 ## ToC:
-Use the syntax `[TOC]` to embed table of content into your note.
+Use the syntax `[TOC]` to embed table of content into your note. By default, three header levels are displayed. This can also be specified by using [YAML Metadata](./yaml-metadata). 
 
 [TOC]
+
+You can also specify the number of header levels by specifying the `maxLevel` like this: `[TOC maxLevel=1]`
+
+[TOC maxLevel=1]
+
+
 
 ## Emoji
 You can type any emoji like this :smile: :smiley: :cry: :wink:

--- a/public/docs/yaml-metadata.md
+++ b/public/docs/yaml-metadata.md
@@ -128,6 +128,22 @@ This option allows you to enable Disqus with your shortname.
 disqus: codimd
 ```
 
+toc
+---
+
+This option allows you to set options regarding the table of contents (toc). Currently, its only option is to set the maxDepth.
+
+**Notice: always use two spaces as indention in YAML metadata!**
+
+
+> **maxDepth:**
+> default: not set (whioch will show everything until level 3 (h1 -- h3))
+> max: 5 (as defined by doctoc)
+
+
+**Example**
+
+
 type
 ---
 This option allows you to switch the document view to the slide preview, to simplify live editing of presentations.

--- a/public/docs/yaml-metadata.md
+++ b/public/docs/yaml-metadata.md
@@ -138,7 +138,7 @@ This option allows you to set options regarding the table of contents (toc). Cur
 
 > **maxDepth:**
 > default: not set (whioch will show everything until level 3 (h1 -- h3))
-> max: 5 (as defined by doctoc)
+> max: 5 (as defined by md-toc.js)
 
 
 **Example**

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -813,7 +813,7 @@ export function generateToc (id) {
   /* eslint-disable no-unused-vars */
 
   var tocOptions = md.meta.toc || {}
-  var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : 3
+  var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : window.defaultTocDepth
 
   var toc = new window.Toc('doc', {
     level: maxLevel,
@@ -1016,7 +1016,7 @@ export function renderTOC (view) {
     /* eslint-disable no-unused-vars */
 
     var tocOptions = md.meta.toc || {}
-    var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : 3
+    var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : window.defaultTocDepth
 
     const TOC = new window.Toc('doc', {
       level: maxLevel,

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -811,8 +811,12 @@ export function generateToc (id) {
   const target = $(`#${id}`)
   target.html('')
   /* eslint-disable no-unused-vars */
+
+  var tocOptions = md.meta.toc || {}
+  var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : 3
+
   var toc = new window.Toc('doc', {
-    level: 3,
+    level: maxLevel,
     top: -1,
     class: 'toc',
     ulClass: 'nav',
@@ -1010,8 +1014,12 @@ export function renderTOC (view) {
     const target = $(`#${id}`)
     target.html('')
     /* eslint-disable no-unused-vars */
+
+    var tocOptions = md.meta.toc || {}
+    var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : 3
+
     const TOC = new window.Toc('doc', {
-      level: 3,
+      level: maxLevel,
       top: -1,
       class: 'toc',
       targetId: id,

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1015,14 +1015,19 @@ export function renderTOC (view) {
     target.html('')
     /* eslint-disable no-unused-vars */
 
+    const specificDepth = parseInt(toc.data('toc-depth'))
+
     var tocOptions = md.meta.toc || {}
-    var maxLevel = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : window.defaultTocDepth
+    var yamlMaxDepth = (typeof tocOptions.maxLevel === 'number' && tocOptions.maxLevel > 0) ? tocOptions.maxLevel : window.defaultTocDepth
+
+    var maxLevel = specificDepth || yamlMaxDepth
 
     const TOC = new window.Toc('doc', {
       level: maxLevel,
       top: -1,
       class: 'toc',
       targetId: id,
+      data: { tocDepth: specificDepth },
       process: getHeaderContent
     })
     /* eslint-enable no-unused-vars */
@@ -1268,9 +1273,12 @@ const gistPlugin = new Plugin(
 // TOC
 const tocPlugin = new Plugin(
   // regexp to match
-  /^\[TOC\]$/i,
+  /^\[TOC(|\s*maxLevel=\d+?)\]$/i,
 
-  (match, utils) => '<div class="toc"></div>'
+  (match, utils) => {
+    const tocDepth = match[1].split(/[?&=]+/)[1]
+    return `<div class="toc" data-toc-depth="${tocDepth}"></div>`
+  }
 )
 // slideshare
 const slidesharePlugin = new Plugin(

--- a/public/js/lib/common/constant.ejs
+++ b/public/js/lib/common/constant.ejs
@@ -13,3 +13,5 @@ window.linkifyHeaderStyle = '<%- linkifyHeaderStyle %>'
 window.DROPBOX_APP_KEY = '<%- DROPBOX_APP_KEY %>'
 
 window.USE_CDN = <%- useCDN %>
+
+window.defaultTocDepth = <%- defaultTocDepth %>

--- a/public/vendor/md-toc.js
+++ b/public/vendor/md-toc.js
@@ -2,6 +2,8 @@
 /**
  * md-toc.js v1.0.2
  * https://github.com/yijian166/md-toc.js
+ *
+ * Adapted to accept data attributes
  */
 
 (function (window) {
@@ -15,6 +17,7 @@
     this.tocTop = parseInt(options.top) || 0
     this.elChilds = this.el.children
     this.process = options['process']
+    this.data = options.data || {}
     if (!this.elChilds.length) return
     this._init()
   }
@@ -123,6 +126,9 @@
     this.toc = document.createElement('div')
     this.toc.innerHTML = this.tocContent
     this.toc.setAttribute('class', this.tocClass)
+    if (this.data.tocDepth) {
+      this.toc.dataset.tocDepth = this.data.tocDepth
+    }
     if (!this.options.targetId) {
       this.el.appendChild(this.toc)
     } else {


### PR DESCRIPTION
This commit allows one to set the depth of the table of contents freely by means of YAML metadata or an option directly within the `[toc]` tag (e.g. `[toc maxLevel=4]`. The default level can also be set by means of the environment variable `CMD_DEFAULT_TOC_DEPTH`, this variable defaults to 3. The toc depth of the automatically generated toc can only be set by setting the level in the YAML or below.

The precedence of the toc depth is as follows (highest to lowest): `[toc maxLevel=4]` > YAML metadata > `CMD_DEFAULT_TOC_DEPTH` > 3 (default value)

![codimd-toc-example-customtoc](https://user-images.githubusercontent.com/16545968/83663340-06d73c80-a5c9-11ea-805c-8297a2c06326.png)

## Optional Features
+ [x] It might be nice to set a default depth with an environment variable, though I'm unsure how to access them from the frontend (as I found no example)