### PR TITLE
feature: pass-through yaml metadata image to html meta tag

### DIFF
--- a/lib/note/index.js
+++ b/lib/note/index.js
@@ -121,6 +121,7 @@ async function showPublishNote (req, res) {
   const data = {
     title: title,
     description: meta.description || (markdown ? Note.generateDescription(markdown) : null),
+    image: meta.image,
     viewcount: note.viewcount,
     createtime: createTime,
     updatetime: updateTime,

--- a/public/docs/yaml-metadata.md
+++ b/public/docs/yaml-metadata.md
@@ -40,6 +40,17 @@ This option will set the note description.
 description: meta description
 ```
 
+image
+---
+This option will set the html meta tag 'image'.
+
+> default: not set
+
+**Example**
+```yml
+image: https://raw.githubusercontent.com/hackmdio/codimd/develop/public/screenshot.png
+```
+
 tags
 ---
 This option will set the tags which prior than content tags.

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -11,6 +11,9 @@
     <% if(typeof robots !== 'undefined' && robots) { %>
     <meta name="robots" content="<%= robots %>">
     <% } %>
+    <% if(typeof image !== 'undefined' && image) { %>
+    <meta name="image" content="<%= image %>">
+    <% } %>
     <% if(typeof description !== 'undefined' && description) { %>
     <meta name="description" content="<%= description %>">
     <% } %>


### PR DESCRIPTION
This is referencing the issue 'Support YAML metadata image tag #1545'