### PR TITLE
Allow Sequelize CLI to use options set in config.json

### DIFF
--- a/.sequelizerc.example
+++ b/.sequelizerc.example
@@ -2,8 +2,8 @@ const path = require('path')
 const config = require('./lib/config')
 
 module.exports = {
-  config: path.resolve('config.json'),
+  config: path.resolve('config.js'),
   'migrations-path': path.resolve('lib', 'migrations'),
   'models-path': path.resolve('lib', 'models'),
-  url: process.env['CMD_DB_URL'] || config.dbURL
+  url: config.dbURL
 }

--- a/config.js
+++ b/config.js
@@ -1,0 +1,3 @@
+const config = require('./lib/config')
+
+module.exports = config.db


### PR DESCRIPTION
Until now, the Sequelize CLI received options differently from the actual Sequelize instance created in `lib/models/index.js`. Aside from just being irritating, it prevents any database options from `config.json` from being used by the Sequelize CLI without duplicating them, as @Yukaii points out in #1396.

This PR has the Sequelize CLI use a `config.js` which uses `lib/config` to load the configuration just as the application does.

Fixes #1396
Signed-off-by: Maximilian Haye <mhajoha@gmail.com>