### PR TITLE
Spellcheck: add en_GB dictionary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5404,6 +5404,12 @@
       "integrity": "sha512-+eqpz5j8WONSzxmc4avCN4XX/6q5+J6JfWz2AaluZIOVNgXPxUjXBhKS73+nRhM3nE1pGeRMqkyZevTQWgYTTw==",
       "dev": true
     },
+     "dictionary-en-gb": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dictionary-en-gb/-/dictionary-en-gb-2.2.2.tgz",
+      "integrity": "sha512-36Pz/2BGmJfXtAo5+IGOi+U6gwtxFsFXFJMOX0FC1z2YeLd1IXkxsfAhieC06OrdGie3SqCZmUOYeYgct5Hzzw==",
+      "dev": true
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "dictionary-de": "^2.0.3",
     "dictionary-de-at": "^2.0.3",
     "dictionary-de-ch": "^2.0.3",
+    "dictionary-en-gb": "^2.2.2",
     "doctoc": "~1.4.0",
     "ejs-loader": "~0.3.1",
     "exports-loader": "~0.7.0",

--- a/public/js/lib/editor/spellcheck.js
+++ b/public/js/lib/editor/spellcheck.js
@@ -19,6 +19,18 @@ export const supportLanguages = [
     }
   },
   {
+    name: 'English (United Kingdom)',
+    value: 'en_GB',
+    aff: {
+      url: `${serverurl}/build/dictionary-en-gb/index.aff`,
+      cdnUrl: 'https://cdn.jsdelivr.net/npm/dictionary-en-gb@2.2.2/index.aff'
+    },
+    dic: {
+      url: `${serverurl}/build/dictionary-en-gb/index.dic`,
+      cdnUrl: 'https://cdn.jsdelivr.net/npm/dictionary-en-gb@2.2.2/index.dic'
+    }
+  },
+  {
     name: 'German',
     value: 'de',
     aff: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -182,6 +182,11 @@ module.exports = {
         to: 'dictionary-de-ch/'
       },
       {
+        context: path.join(__dirname, 'node_modules/dictionary-en-gb'),
+        from: '*',
+        to: 'dictionary-en-gb/'
+      },
+      {
         context: path.join(__dirname, 'node_modules/leaflet'),
         from: 'dist',
         to: 'leaflet'


### PR DESCRIPTION
This adds an "English (United Kingdom)" option to the list of spell checkers, using [`dictionary-en-gb`](https://www.npmjs.com/package/dictionary-en-gb).