### PR TITLE
Fix matchInContainer false positives

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -3137,7 +3137,7 @@ function checkInContainerSyntax () {
 
 function matchInContainer (text) {
   var match
-  match = text.match(/:{3,}/g)
+  match = text.match(/(^|\n):::/gm)
   if (match && match.length % 2) {
     return true
   } else {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -3137,7 +3137,7 @@ function checkInContainerSyntax () {
 
 function matchInContainer (text) {
   var match
-  match = text.match(/(^|\n):::/gm)
+  match = text.match(/^:::/gm)
   if (match && match.length % 2) {
     return true
   } else {


### PR DESCRIPTION
The function should match only the beginnings of lines.

For example, see this testcase:
```
:::spoiler
here is a :::
:::
:::
```
The last line should be completed, and the third should not.

Without this patch, the third line is completed and the last is not.

FYI, this patch is not perfect, either.
If the third line is ":::bogus", the parser won't treat it as the closer. But matchInContainer will.
So the right regexp would be /(^|\n):::\s*(success|info|warning|danger|spoiler)($|\s)/ but who cares