### PR TITLE
Better redirection after a successful login

### DIFF
--- a/lib/auth/utils.js
+++ b/lib/auth/utils.js
@@ -5,9 +5,22 @@ const config = require('../config')
 const logger = require('../logger')
 
 exports.setReturnToFromReferer = function setReturnToFromReferer (req) {
-  var referer = req.get('referer')
   if (!req.session) req.session = {}
-  req.session.returnTo = referer
+
+  var referer = req.get('referer')
+  var refererSearchParams = new URLSearchParams(new URL(referer).search)
+  var nextURL = refererSearchParams.get('next')
+
+  if (nextURL) {
+    var isRelativeNextURL = nextURL.indexOf('://') === -1 && !nextURL.startsWith('//')
+    if (isRelativeNextURL) {
+      req.session.returnTo = (new URL(nextURL, config.serverURL)).toString()
+    } else {
+      req.session.returnTo = config.serverURL
+    }
+  } else {
+    req.session.returnTo = referer
+  }
 }
 
 exports.passportGeneralCallback = function callback (accessToken, refreshToken, profile, done) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -32,8 +32,10 @@ function errorForbidden (req, res) {
   if (req.user) {
     responseError(res, '403', 'Forbidden', 'oh no.')
   } else {
+    var nextURL = new URL('', config.serverURL)
+    nextURL.search = new URLSearchParams({ next: req.originalUrl })
     req.flash('error', 'You are not allowed to access this page. Maybe try logging in?')
-    res.redirect(config.serverURL + '/')
+    res.redirect(nextURL.toString())
   }
 }
 


### PR DESCRIPTION
When:
1) you are not logged in
2) and you try to view a private note

Then:
1) you are redirected to the home page and asked to log in
2) once you log in you are not redirected to the note

This PR fixes this situation and redirects user to a note on a successful login.