### PR TITLE
Don't run jsonlint on .vscode jsonc files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "webpack --config webpack.dev.js --progress --colors --watch",
     "doctoc": "doctoc --title='# Table of Contents' README.md",
     "lint": "standard",
-    "jsonlint": "find . -type f -not -ipath \"./node_modules/*\" \\( -name \"*.json\" -o -name \"*.json.*\" \\) | xargs -n 1 -I{} -- bash -c 'echo {}; jq . {} > /dev/null;'",
+    "jsonlint": "find . -type f -not -ipath \"./node_modules/*\" -not -ipath \"./.vscode/*\" \\( -name \"*.json\" -o -name \"*.json.*\" \\) | xargs -n 1 -I{} -- bash -c 'echo {}; jq . {} > /dev/null;'",
     "start": "sequelize db:migrate && node app.js",
     "mocha": "mocha --require intelli-espower-loader --exit ./test --recursive",
     "mocha:ci": "mocha --no-color -R dot --require intelli-espower-loader --exit ./test --recursive",


### PR DESCRIPTION
VSCode uses `jsonc` (JSON with comments) to parse the configuration files. Unfortunately this doesn't work well with `jq` which follows the JSON standard and errors out on comments.