### PR TITLE
Add new config option allowVisibleSource

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,6 +196,7 @@ app.locals.serverURL = config.serverURL
 app.locals.sourceURL = config.sourceURL
 app.locals.allowAnonymous = config.allowAnonymous
 app.locals.allowAnonymousEdits = config.allowAnonymousEdits
+app.locals.allowVisibleSource = config.allowVisibleSource
 app.locals.permission = config.permission
 app.locals.allowPDFExport = config.allowPDFExport
 app.locals.authProviders = {

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -33,6 +33,7 @@ module.exports = {
   allowAnonymousEdits: true,
   allowAnonymousViews: true,
   allowFreeURL: false,
+  allowVisibleSource: false,
   forbiddenNoteIDs: ['robots.txt', 'favicon.ico', 'api'],
   defaultPermission: 'editable',
   dbURL: '',

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -29,6 +29,7 @@ module.exports = {
   allowAnonymousEdits: toBooleanConfig(process.env.CMD_ALLOW_ANONYMOUS_EDITS),
   allowAnonymousViews: toBooleanConfig(process.env.CMD_ALLOW_ANONYMOUS_VIEWS),
   allowFreeURL: toBooleanConfig(process.env.CMD_ALLOW_FREEURL),
+  allowVisibleSource: toBooleanConfig(process.env.CMD_ALLOW_VISIBLE_SOURCE),
   forbiddenNoteIDs: toArrayConfig(process.env.CMD_FORBIDDEN_NOTE_IDS),
   defaultPermission: process.env.CMD_DEFAULT_PERMISSION,
   dbURL: process.env.CMD_DB_URL,

--- a/public/views/codimd/header.ejs
+++ b/public/views/codimd/header.ejs
@@ -76,20 +76,35 @@
                 <li role="presentation"><a role="menuitem" class="ui-help" href="#" data-toggle="modal" data-target=".help-modal"><i class="fa fa-question-circle fa-fw"></i> Help</a>
                 </li>
             </ul>
-            <a class="btn btn-link ui-mode">
+            <% if(!allowVisibleSource) { %>
+            <a class="btn btn-link ui-mode" data-block-source="<%= !allowVisibleSource %>">
                 <i class="fa fa-pencil"></i>
             </a>
+            <% } else { %>
+            <a class="btn btn-link ui-mode" data-block-source="<%= !allowVisibleSource %>">
+                <i class="fa fa-pencil"></i>
+            </a>
+            <% } %>
         </div>
     </div>
     <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-form navbar-left" style="padding:0;">
             <div class="btn-group" data-toggle="buttons">
-                <label class="btn btn-default ui-edit" title="<%= __('Edit') %> (Ctrl+Alt+E)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
-                </label>
-                <label class="btn btn-default ui-both" title="<%= __('Both') %> (Ctrl+Alt+B)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-columns"></i>
-                </label>
+                <% if(!allowVisibleSource) { %>
+                    <label class="btn btn-default ui-edit" data-block-source="<%= !allowVisibleSource %>" title="<%= __('Edit') %> (Ctrl+Alt+E)">
+                        <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
+                    </label>
+                    <label class="btn btn-default ui-both" data-block-source="<%= !allowVisibleSource %>" title="<%= __('Both') %> (Ctrl+Alt+B)">
+                        <input type="radio" name="mode" autocomplete="off"><i class="fa fa-columns"></i>
+                    </label>
+                <% } else { %>
+                    <label class="btn btn-default ui-edit" data-block-source="<%= !allowVisibleSource %>" title="<%= __('Edit') %> (Ctrl+Alt+E)">
+                        <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
+                    </label>
+                    <label class="btn btn-default ui-both" data-block-source="<%= !allowVisibleSource %>" title="<%= __('Both') %> (Ctrl+Alt+B)">
+                        <input type="radio" name="mode" autocomplete="off"><i class="fa fa-columns"></i>
+                    </label>
+                <% } %>
                 <label class="btn btn-default ui-view" title="<%= __('View') %> (Ctrl+Alt+V)">
                     <input type="radio" name="mode" autocomplete="off"><i class="fa fa-eye"></i>
                 </label>


### PR DESCRIPTION
Add new config option allowVisibleSource to the project. The default value for this option is true. The false value will block Edit and Both editor modes for users that have no rights to edit a note.

Pull request adds:

- new config option allowVisibleSource with default value true;
- new environment variable CMD_VISIBLE_SOURCE;
- disable Edit and Both modes for users without edit note permission;
- redirect form Edit and Both modes to View mode by direct URL with mode parameter.