### PR TITLE
Fix slide mode stored XSS

### DIFF
--- a/public/js/reveal-markdown.js
+++ b/public/js/reveal-markdown.js
@@ -103,7 +103,7 @@ import { md } from './extra'
 
     // prevent script end tags in the content from interfering
     // with parsing
-    content = content.replace(/<\/script>/g, SCRIPT_END_PLACEHOLDER)
+    content = content.replace(/<\/script>/gi, SCRIPT_END_PLACEHOLDER)
 
     return '<script type="text/template">' + content + '</script>'
   }

--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -80,6 +80,8 @@ const defaultOptions = {
 }
 
 var options = meta.slideOptions || {}
+// delete dependencies to avoid import user defined external resources
+delete options.dependencies
 
 if (Object.hasOwnProperty.call(options, 'spotlight')) {
   defaultOptions.dependencies.push({


### PR DESCRIPTION
Fixes #1648 

Since meta-marked uses js-yaml and parse meta with `yaml.safeLoad`, there is no way the yaml can get js function or regex out. We only need to remove library load external resources.