### PR TITLE
fix: avoid insert embed tag on the main thread which cause Safari on Big Sur freezing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12440,9 +12440,9 @@
       }
     },
     "pdfobject": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pdfobject/-/pdfobject-2.1.1.tgz",
-      "integrity": "sha512-QFktTHyjs4q/WhGFfV2RdAbscPdNkyQb/JfFz18cwILvs9ocDiYVFAEh/jgkKGv6my+r4nlbLjwj7BHFKAupHQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/pdfobject/-/pdfobject-2.2.4.tgz",
+      "integrity": "sha512-r6Rw9CQWsrY6uqmKvlgFNoupmuRbSt9EsG0sZhSAy3cIk4WgOXyAVmebFSlLhqj6gA5NIEXL3lSEbwOOYfdUvw==",
       "dev": true
     },
     "pend": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "nyc": "~14.0.0",
     "optimize-css-assets-webpack-plugin": "~5.0.0",
     "papaparse": "^5.2.0",
-    "pdfobject": "～2.2.4",
+    "pdfobject": "~2.2.4",
     "plantuml-encoder": "^1.2.5",
     "power-assert": "~1.6.1",
     "prismjs": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "nyc": "~14.0.0",
     "optimize-css-assets-webpack-plugin": "~5.0.0",
     "papaparse": "^5.2.0",
-    "pdfobject": "~2.1.1",
+    "pdfobject": "～2.2.4",
     "plantuml-encoder": "^1.2.5",
     "power-assert": "~1.6.1",
     "prismjs": "^1.17.1",

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -597,9 +597,11 @@ export function finishView (view) {
       const url = $(value).attr('data-pdfurl')
       const inner = $('<div></div>')
       $(this).append(inner)
-      PDFObject.embed(url, inner, {
-        height: '400px'
-      })
+      setTimeout(() => {
+        PDFObject.embed(url, inner, {
+          height: '400px'
+        })
+      }, 1)
     })
     // syntax highlighting
   view.find('code.raw').removeClass('raw')


### PR DESCRIPTION
Also upgrade pdfobject to version 2.2.4

This might be a bug in Safari on Big Sur, make a workaround anyways.