### PR TITLE
fix: webpack exclude path should support windows path

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -443,7 +443,10 @@ module.exports = {
     }, {
       test: /\.js$/,
       use: [{ loader: 'babel-loader' }],
-      exclude: [/node_modules/, /public\/vendor/]
+      exclude: [
+        path.resolve(__dirname, 'node_modules'),
+        path.resolve(__dirname, 'public/vendor')
+      ]
     }, {
       test: /\.css$/,
       use: [


### PR DESCRIPTION
1. webpack build will failed in windows 