### PR TITLE
Handle when request url has no valid referer

### DIFF
--- a/lib/auth/utils.js
+++ b/lib/auth/utils.js
@@ -8,8 +8,15 @@ exports.setReturnToFromReferer = function setReturnToFromReferer (req) {
   if (!req.session) req.session = {}
 
   var referer = req.get('referer')
-  var refererSearchParams = new URLSearchParams(new URL(referer).search)
-  var nextURL = refererSearchParams.get('next')
+  var nextURL
+  if (referer) {
+    try {
+      var refererSearchParams = new URLSearchParams(new URL(referer).search)
+      nextURL = refererSearchParams.get('next')
+    } catch (err) {
+      logger.warn(err)
+    }
+  }
 
   if (nextURL) {
     var isRelativeNextURL = nextURL.indexOf('://') === -1 && !nextURL.startsWith('//')


### PR DESCRIPTION
As our cli tool is not passing referer header on requesting server, this will lead to fail login by PR #1609

Signed-off-by: Max Wu <jackymaxj@gmail.com>