### PR TITLE
refactor: use AWS SDK instead of old libraries

### DIFF
--- a/lib/imageRouter/s3.js
+++ b/lib/imageRouter/s3.js
@@ -6,8 +6,9 @@ const config = require('../config')
 const { getImageMimeType } = require('../utils')
 const logger = require('../logger')
 
-const { S3Client } = require('@aws-sdk/client-s3-node/S3Client')
-const { PutObjectCommand } = require('@aws-sdk/client-s3-node/commands/PutObjectCommand')
+const AWS = require('aws-sdk')
+const awsConfig = new AWS.Config(config.s3)
+const s3 = new AWS.S3(awsConfig)
 
 const credentials = {
   accessKeyId: config.s3.accessKeyId,
@@ -45,9 +46,12 @@ exports.uploadImage = function (imagePath, callback) {
     const mimeType = getImageMimeType(imagePath)
     if (mimeType) { params.ContentType = mimeType }
 
-    const command = new PutObjectCommand(params)
+    s3.putObject(params, function (err, data) {
+      if (err) {
+        callback(new Error(err), null)
+        return
+      }
 
-    s3.send(command).then(data => {
       let s3Endpoint = 's3.amazonaws.com'
       if (config.s3.endpoint) {
         s3Endpoint = config.s3.endpoint
@@ -55,10 +59,6 @@ exports.uploadImage = function (imagePath, callback) {
         s3Endpoint = `s3-${config.s3.region}.amazonaws.com`
       }
       callback(null, `https://${s3Endpoint}/${config.s3bucket}/${params.Key}`)
-    }).catch(err => {
-      if (err) {
-        callback(new Error(err), null)
-      }
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "heroku-postbuild": "npm run build && ./bin/heroku"
   },
   "dependencies": {
-    "@aws-sdk/client-s3-node": "0.1.0-preview.2",
     "@hackmd/diff-match-patch": "~1.1.3",
     "@hackmd/imgur": "~0.5.0",
     "@hackmd/lz-string": "~1.4.4",
@@ -39,6 +38,7 @@
     "@passport-next/passport-openid": "~1.0.0",
     "archiver": "~3.1.1",
     "async": "~3.1.0",
+    "aws-sdk": "^2.521.0",
     "azure-storage": "~2.10.3",
     "babel-polyfill": "~6.26.0",
     "base64url": "~3.0.1",


### PR DESCRIPTION
It should fix #1717 

AWS SDK official was used here and it should revert https://github.com/hackmdio/codimd/commit/2fe10a78b73c357acb612c33ac925b49afed0526