### PR TITLE
FIX: pandoc security issue

### DIFF
--- a/lib/note/noteActions.js
+++ b/lib/note/noteActions.js
@@ -132,14 +132,17 @@ async function actionPandoc (req, res, note) {
   var path = config.tmpPath + '/' + Date.now()
   content = content.replace(/\]\(\//g, '](' + url + '/')
 
-  // TODO: check export type
   const { exportType } = req.query
+  const contentType = outputFormats[exportType]
 
   try {
     // TODO: timeout rejection
+    if (!contentType) {
+      return res.sendStatus(400)
+    }
 
     await pandoc.convertToFile(content, 'markdown', exportType, path, [
-      '--metadata', `title=${title}`
+      '--metadata', `title=${title}`, '--sandbox'
     ])
 
     var stream = fs.createReadStream(path)
@@ -149,7 +152,7 @@ async function actionPandoc (req, res, note) {
     // Ideally this should strip them
     res.setHeader('Content-disposition', `attachment; filename="${filename}.${exportType}"`)
     res.setHeader('Cache-Control', 'private')
-    res.setHeader('Content-Type', `${outputFormats[exportType]}; charset=UTF-8`)
+    res.setHeader('Content-Type', `${contentType}; charset=UTF-8`)
     res.setHeader('X-Robots-Tag', 'noindex, nofollow') // prevent crawling
     stream.pipe(res)
   } catch (err) {


### PR DESCRIPTION
According to pandoc's [manual](https://pandoc.org/MANUAL.html#a-note-on-security)
some file format can include or embed files on the file system.

Check param `exportType` is valid & running pandoc with `--sandbox` to fix this.