### PR TITLE
fix(buildpacks): replace custom buildpack with APT buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/alex88/heroku-buildpack-vips
+https://github.com/Scalingo/apt-buildpack
 https://github.com/Scalingo/nodejs-buildpack

--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+libvips-dev


### PR DESCRIPTION
Fix the Scalingo deployment by using the Scalingo official recommandation for VIPS (https://doc.scalingo.com/languages/ruby/rails/start#use-vips-to-process-image).