### PR TITLE
fix: use encoded note id to update history

### DIFF
--- a/lib/note/index.js
+++ b/lib/note/index.js
@@ -309,7 +309,7 @@ const updateNote = async (req, res) => {
       }
 
       if (req.isAuthenticated()) {
-        updateHistory(req.user.id, noteId, content)
+        updateHistory(req.user.id, Note.encodeNoteId(noteId), content)
       }
 
       Revision.saveNoteRevision(note, (err, revision) => {


### PR DESCRIPTION
fixes: https://github.com/hackmdio/codimd/pull/1570

In the current version, if I call `PUT /api/notes/:noteId`, my note will be updated properly, but in history page, I will get 2 notes with the same name, one linked to `/uuid` (which can not be opened, 404) and the other linked to `/encoded_id` (this is what I want)

I did some digging, and noticed that both `note.id` and `noteId` here in `updateNote` are uuid, not encoded note id, we have to call `Note.encodeNoteId` to make it work 