### PR TITLE
feat: add check-release workflow

### DIFF
--- a/.github/tests/README.md
+++ b/.github/tests/README.md
@@ -1,0 +1,6 @@
+# Test github actions with act
+
+```bash
+act pull_request --container-architecture linux/arm64 -e .github/tests/pull-request.json -j ch
+eck-release-pr -P ubuntu-latest=catthehacker/ubuntu:act-latest
+```

--- a/.github/tests/pull-request.json
+++ b/.github/tests/pull-request.json
@@ -1,0 +1,10 @@
+{
+  "pull_request": {
+    "head": {
+      "ref": "release/1.2.3"
+    },
+    "base": {
+      "ref": "master"
+    }
+  }
+}

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,41 @@
+name: Release PR Checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-release-pr:
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check for release-notes updates
+        run: |
+          if ! git diff --exit-code origin/develop -- public/docs/release-notes.md; then
+            echo "Release notes updated."
+          else
+            echo "Error: Release notes not updated in the PR."
+            exit 1
+          fi
+
+      - name: Compare package.json version with master
+        run: |
+          git fetch origin master
+          MASTER_PACKAGE_VERSION=$(git show origin/master:package.json | jq -r '.version')
+          BRANCH_PACKAGE_VERSION=$(jq -r '.version' package.json)
+
+          if [ "$BRANCH_PACKAGE_VERSION" != "$MASTER_PACKAGE_VERSION" ]; then
+            echo "Version bumped in package.json."
+          else
+            echo "Error: Version in package.json has not been bumped."
+            exit 1
+          fi
+


### PR DESCRIPTION
Check if both `public/docs/release-note.md` and `package.json` are updated.

And yes, I didn't bump the version 2.5.2. 😓 That's the reason for this PR.

