### PR TITLE
chore: update docker-compose default image version to 2.5.3

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -11,10 +11,7 @@ services:
     restart: always
   codimd:
     # you can use image or custom build below,
-    # if you need CJK character with exported PDF files,
-    # please change the image tag with `cjk` postfix version
-    image: nabo.codimd.dev/hackmdio/hackmd:2.1.0
-    # image: nabo.codimd.dev/hackmdio/hackmd:2.1.0-cjk
+    image: nabo.codimd.dev/hackmdio/hackmd:2.5.3
     # build:
     #   context: ..
     #   dockerfile: ./deployments/Dockerfile


### PR DESCRIPTION
Signed-off-by: Yukai Huang <yukaihuangtw@gmail.com>
