### PR TITLE
Add index at revision table for improving system performance  🚀 

### DIFF
--- a/lib/migrations/20240114120250-revision-add-index.js
+++ b/lib/migrations/20240114120250-revision-add-index.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
@@ -8,4 +8,4 @@ module.exports = {
   down: (queryInterface, Sequelize) => {
     return queryInterface.removeIndex('Revisions', 'noteId')
   }
-};
+}

--- a/lib/migrations/20240114120250-revision-add-index.js
+++ b/lib/migrations/20240114120250-revision-add-index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addIndex('Revisions', ['noteId'], {})
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('Revisions', 'noteId')
+  }
+};


### PR DESCRIPTION
The SQLs to select records from the revision table is a sequential scan.
These SQLs use note id as a search key, but there is no index on the note id column.

I want to change to index scan to improve system performance 🚀 
The records in the revision table will become huge during operation, so sequential scans should be avoided.
This is especially because the following fetch processing is called frequently.

https://github.com/hackmdio/codimd/blob/d157fde6667185ab09125fa18317152eeef15fb4/app.js#L277

For your reference, the organization I belong to has already changed it. (https://github.com/kufu/hackmd/pull/19)
