### PR TITLE
Add baseURL configuration option to S3 modules

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -74,7 +74,8 @@ module.exports = {
     accessKeyId: undefined,
     secretAccessKey: undefined,
     region: undefined,
-    endpoint: undefined
+    endpoint: undefined,
+    baseURL: undefined
   },
   minio: {
     accessKey: undefined,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -44,7 +44,8 @@ module.exports = {
     accessKeyId: process.env.CMD_S3_ACCESS_KEY_ID,
     secretAccessKey: process.env.CMD_S3_SECRET_ACCESS_KEY,
     region: process.env.CMD_S3_REGION,
-    endpoint: process.env.CMD_S3_ENDPOINT
+    endpoint: process.env.CMD_S3_ENDPOINT,
+    baseURL: process.env.CMD_S3_BASEURL
   },
   minio: {
     accessKey: process.env.CMD_MINIO_ACCESS_KEY,

--- a/lib/imageRouter/s3.js
+++ b/lib/imageRouter/s3.js
@@ -57,7 +57,11 @@ exports.uploadImage = function (imagePath, callback) {
       if (config.s3.endpoint) {
         s3Endpoint = config.s3.endpoint
       }
-      callback(null, `${s3Endpoint}/${config.s3bucket}/${params.Key}`)
+      if (config.s3.baseURL) {
+        callback(null, `${config.s3.baseURL}/${params.Key}`)
+      } else {
+        callback(null, `${s3Endpoint}/${config.s3bucket}/${params.Key}`)
+      }
     }).catch(err => {
       if (err) {
         callback(new Error(err), null)


### PR DESCRIPTION
close #1872 

This change allows you to replace the S3 endpoint with a different domain, for example when distributing images using a CDN.

- Added `s3.baseURL` option.
- If `s3.baseURL` is set, the image URL will be changed to `${s3.baseURL}/${params.key}`.