### PR TITLE
feature/dev 1879 improve contrast on certain elements

### DIFF
--- a/public/css/codemirror-extend/one-dark.css
+++ b/public/css/codemirror-extend/one-dark.css
@@ -1,0 +1,13 @@
+.cm-s-one-dark .CodeMirror-linenumber {
+  color: #676767;
+}
+
+.cm-s-one-dark.CodeMirror-focused
+  .CodeMirror-activeline
+  .CodeMirror-gutter-elt {
+  color: #b0b0b0;
+}
+
+.cm-s-one-dark .cm-comment {
+  color: #818895;
+}

--- a/public/css/extra.css
+++ b/public/css/extra.css
@@ -106,6 +106,9 @@
     margin-bottom: -25px;
     color: #777;
 }
+.night .ui-infobar {
+  color: #ededed;
+}
 
 .toc .invisable-node {
   list-style-type: none;
@@ -454,7 +457,8 @@ small .dropdown a:focus, small .dropdown a:hover {
     color: #eee;
 }
 
-.night .navbar a{
+.night .navbar-default .navbar-nav > li > a,
+.night .navbar a {
     color: #eee;
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -329,6 +329,11 @@ body.night{
     background: #000;
 
 }
+
+.night .navbar-default .btn-link {
+  color: #bbb;
+}
+
 .dropdown-menu > li > a {
     cursor: pointer;
     text-overflow: ellipsis;
@@ -343,6 +348,10 @@ body.night{
 .night .dropdown-menu > li > a:focus,
 .night .dropdown-menu > li > a:hover {
   color: #262626
+}
+
+.night .status-bar .dropdown-menu > li > a:focus, .status-bar .dropdown-menu > li > a:hover {
+    color: #ccc;
 }
 
 .night .dropdown-menu {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -263,6 +263,7 @@ module.exports = {
       path.join(__dirname, 'public/css/codemirror-extend/ayu-mirage.css'),
       path.join(__dirname, 'public/css/codemirror-extend/tomorrow-night-bright.css'),
       path.join(__dirname, 'public/css/codemirror-extend/tomorrow-night-eighties.css'),
+      path.join(__dirname, 'public/css/codemirror-extend/one-dark.css'),
       path.join(__dirname, 'node_modules/@hackmd/codemirror/mode/tiddlywiki/tiddlywiki.css'),
       path.join(__dirname, 'node_modules/@hackmd/codemirror/mode/mediawiki/mediawiki.css'),
       path.join(__dirname, 'public/css/github-extract.css'),


### PR DESCRIPTION
Improve contrast of UI elements:
- Default theme now has higher contrast linenumber & code comments.
The link buttons in the navbar, last changed at, and the action button on the top right are now more visible in dark mode.
- Fix an issue where the theme name would not be visible when hovering under dark mode.

Before:
![Screenshot_20250321_115308](https://github.com/user-attachments/assets/ce65feba-3298-451a-81bb-362941105327)

After:
![Screenshot_20250321_115243](https://github.com/user-attachments/assets/62340c8e-b056-492e-b17c-081e3c48ab36)


The color of active line is also updated:
(Before)
![image](https://github.com/user-attachments/assets/a6c3ddf1-cfbf-4e61-aa85-e0a8e0694e01)
(After)
![image](https://github.com/user-attachments/assets/82b62143-2e5b-4d4a-ac30-88a1a5a70c70)
