### PR TITLE
Add preference to disable table editor shortcuts and migrate preferences to localStorage

### DIFF
--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -779,6 +779,41 @@ export default class Editor {
     overrideBrowserKeymap.change(() => {
       this.setOverrideBrowserKeymap()
     })
+
+    // Handle table editor shortcuts preference
+    var disableTableShortcuts = $(
+      '.ui-preferences-disable-table-shortcuts label > input[type="checkbox"]'
+    )
+    var cookieDisableTableShortcuts = Cookies.get(
+      'preferences-disable-table-shortcuts'
+    )
+    if (cookieDisableTableShortcuts && cookieDisableTableShortcuts === 'true') {
+      disableTableShortcuts.prop('checked', true)
+    } else {
+      disableTableShortcuts.prop('checked', false)
+    }
+    this.setTableShortcutsPreference()
+
+    disableTableShortcuts.change(() => {
+      this.setTableShortcutsPreference()
+    })
+  }
+
+  setTableShortcutsPreference () {
+    var disableTableShortcuts = $(
+      '.ui-preferences-disable-table-shortcuts label > input[type="checkbox"]'
+    )
+    if (disableTableShortcuts.is(':checked')) {
+      Cookies.set('preferences-disable-table-shortcuts', true, {
+        expires: 365
+      })
+    } else {
+      Cookies.remove('preferences-disable-table-shortcuts')
+    }
+    // Notify table editor about the preference change
+    if (this.tableEditor) {
+      this.tableEditor.setShortcutsEnabled(!disableTableShortcuts.is(':checked'))
+    }
   }
 
   init (textit) {

--- a/public/js/lib/editor/statusbar.html
+++ b/public/js/lib/editor/statusbar.html
@@ -14,6 +14,7 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="preferencesLabel">
                 <li class="ui-preferences-override-browser-keymap"><a><label>Allow override browser keymap&nbsp;&nbsp;<input type="checkbox"></label></a></li>
+                <li class="ui-preferences-disable-table-shortcuts"><a><label>Disable table editor shortcuts&nbsp;&nbsp;<input type="checkbox"></label></a></li>
             </ul>
         </div>
         <div class="status-keymap dropup pull-right">

--- a/public/js/lib/editor/table-editor.js
+++ b/public/js/lib/editor/table-editor.js
@@ -125,6 +125,28 @@ export function initTableEditor (editor) {
     smartCursor: true,
     formatType: FormatType.NORMAL
   })
+
+  // Flag to track if shortcuts are enabled
+  let shortcutsEnabled = true
+
+  // Method to enable/disable shortcuts
+  tableEditor.setShortcutsEnabled = function (enabled) {
+    shortcutsEnabled = enabled
+    // If shortcuts are disabled and currently active, remove the keymap
+    if (!enabled && lastActive) {
+      editor.removeKeyMap(keyMap)
+    } else if (enabled && lastActive) {
+      // If shortcuts are enabled and cursor is in table, add the keymap back
+      editor.addKeyMap(keyMap)
+    }
+  }
+
+  // Check cookie for saved preference
+  const cookieDisableTableShortcuts = window.Cookies && window.Cookies.get('preferences-disable-table-shortcuts')
+  if (cookieDisableTableShortcuts && cookieDisableTableShortcuts === 'true') {
+    shortcutsEnabled = false
+  }
+
   // keymap of the commands
   // from https://github.com/susisu/mte-demo/blob/master/src/main.js
   const keyMap = CodeMirror.normalizeKeyMap({
@@ -178,7 +200,10 @@ export function initTableEditor (editor) {
     if (active) {
       tableTools.show()
       tableTools.parent().scrollLeft(tableTools.parent()[0].scrollWidth)
-      editor.addKeyMap(keyMap)
+      // Only add keymap if shortcuts are enabled
+      if (shortcutsEnabled) {
+        editor.addKeyMap(keyMap)
+      }
     } else {
       tableTools.hide()
       editor.removeKeyMap(keyMap)


### PR DESCRIPTION
Introduce a new preference option to disable shortcuts in the table editor and migrate user preferences from cookies to localStorage for better management.