### PR TITLE
chore/bump codemirror version to 5.65.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "ws": "~7.1.1"
       },
       "devDependencies": {
-        "@hackmd/codemirror": "~5.63.2",
+        "@hackmd/codemirror": "^5.65.8",
         "@hackmd/emojify.js": "^2.1.0",
         "@hackmd/idle-js": "~1.0.1",
         "@hackmd/js-sequence-diagrams": "~0.0.1-alpha.3",
@@ -978,10 +978,11 @@
       }
     },
     "node_modules/@hackmd/codemirror": {
-      "version": "5.63.2",
-      "resolved": "https://registry.npmjs.org/@hackmd/codemirror/-/codemirror-5.63.2.tgz",
-      "integrity": "sha512-0BYPBdQtDB20TtL481GhI9iAQa6Bd7mQ6GB39QqpAUZ6O1qu4PhZTrFzO2mJVdD9B5cuRubL9DlbKXStt9bTuw==",
-      "dev": true
+      "version": "5.65.8",
+      "resolved": "https://registry.npmjs.org/@hackmd/codemirror/-/codemirror-5.65.8.tgz",
+      "integrity": "sha512-yPTxHIjN3ORKOK2E139MA5pgSwwX/T+k8zkj2FJg80ahn2w1txXHLA8LdpBFF6Vxfb8A5oX3QzbTp/aIO6b3iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@hackmd/diff-match-patch": {
       "version": "1.1.3",
@@ -23137,9 +23138,9 @@
       }
     },
     "@hackmd/codemirror": {
-      "version": "5.63.2",
-      "resolved": "https://registry.npmjs.org/@hackmd/codemirror/-/codemirror-5.63.2.tgz",
-      "integrity": "sha512-0BYPBdQtDB20TtL481GhI9iAQa6Bd7mQ6GB39QqpAUZ6O1qu4PhZTrFzO2mJVdD9B5cuRubL9DlbKXStt9bTuw==",
+      "version": "5.65.8",
+      "resolved": "https://registry.npmjs.org/@hackmd/codemirror/-/codemirror-5.65.8.tgz",
+      "integrity": "sha512-yPTxHIjN3ORKOK2E139MA5pgSwwX/T+k8zkj2FJg80ahn2w1txXHLA8LdpBFF6Vxfb8A5oX3QzbTp/aIO6b3iA==",
       "dev": true
     },
     "@hackmd/diff-match-patch": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "ws": "~7.1.1"
   },
   "devDependencies": {
-    "@hackmd/codemirror": "~5.63.2",
+    "@hackmd/codemirror": "^5.65.8",
     "@hackmd/emojify.js": "^2.1.0",
     "@hackmd/idle-js": "~1.0.1",
     "@hackmd/js-sequence-diagrams": "~0.0.1-alpha.3",


### PR DESCRIPTION
Bumping Codemirror to version 5.65.8 addressed an issue on Firefox: The editor would break if the user tried to input after right-clicking on it.