### PR TITLE
fix: login email should be case insensitive

### DIFF
--- a/lib/auth/email/index.js
+++ b/lib/auth/email/index.js
@@ -2,6 +2,7 @@
 
 const Router = require('express').Router
 const passport = require('passport')
+const sequelize = require('sequelize')
 const validator = require('validator')
 const LocalStrategy = require('passport-local').Strategy
 const config = require('../../config')
@@ -21,7 +22,10 @@ passport.use(new LocalStrategy({
   try {
     const user = await models.User.findOne({
       where: {
-        email: email
+        email: sequelize.where(
+          sequelize.fn('LOWER', sequelize.col('email')),
+          email.toLowerCase()
+        )
       }
     })
 


### PR DESCRIPTION
fix #1744
By query email in lower case makes login be case insensitive now
tested on: Postgres12 & sqlite3