### PR TITLE
VSCode: update image to allow development on MBP ARM chips

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Node.js version: 16, 14
-ARG VARIANT=14-buster
+ARG VARIANT=14-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        VARIANT: 14-buster
+        VARIANT: 14-bullseye
     environment:
       - CMD_DB_URL=postgres://codimd:codimd@localhost/codimd
       - CMD_USECDN=false


### PR DESCRIPTION
Based on [what people say](https://github.com/microsoft/generative-ai-for-beginners/issues/187#issuecomment-1822014162), `14-buster` can't run on MBP ARM - but `14-bullseye` can. I was able to get it working.

Note that I saw some PhantomJS related errors in the terminal output, but that didn't prevent me from being able to contribute. But it likely means this PR isn't complete. :) Hope you could take it over and ensure it's good and everything.