### PR TITLE
refactor: migrate RevealMarkdown to ES module imports

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2749,13 +2749,14 @@ function updateViewInner () {
   delete md.metaError
   var rendered = md.render(value)
   if (md.meta.type && md.meta.type === 'slide') {
+    var RevealMarkdown = require('./reveal-markdown').default
     var slideOptions = {
       separator: '^(\r\n?|\n)---(\r\n?|\n)$',
       verticalSeparator: '^(\r\n?|\n)----(\r\n?|\n)$'
     }
-    var slides = window.RevealMarkdown.slidify(editor.getValue(), slideOptions)
+    var slides = RevealMarkdown.slidify(editor.getValue(), slideOptions)
     ui.area.markdown.html(slides)
-    window.RevealMarkdown.initialize()
+    RevealMarkdown.initialize()
     // prevent XSS
     ui.area.markdown.html(preventXSS(ui.area.markdown.html()))
     ui.area.markdown.addClass('slides')

--- a/public/js/pretty.js
+++ b/public/js/pretty.js
@@ -1,5 +1,6 @@
 /* eslint-env browser, jquery */
 /* global refreshView */
+import RevealMarkdown from './reveal-markdown'
 
 import {
   autoLinkify,
@@ -35,9 +36,9 @@ if (md.meta.type && md.meta.type === 'slide') {
     separator: '^(\r\n?|\n)---(\r\n?|\n)$',
     verticalSeparator: '^(\r\n?|\n)----(\r\n?|\n)$'
   }
-  const slides = window.RevealMarkdown.slidify(text, slideOptions)
+  const slides = RevealMarkdown.slidify(text, slideOptions)
   markdown.html(slides)
-  window.RevealMarkdown.initialize()
+  RevealMarkdown.initialize()
   // prevent XSS
   markdown.html(preventXSS(markdown.html()))
   markdown.addClass('slides')

--- a/public/js/reveal-markdown.js
+++ b/public/js/reveal-markdown.js
@@ -354,3 +354,14 @@ import { md } from './extra'
     slidify: slidify
   }
 }))
+
+// ES Module export for modern imports
+const RevealMarkdownAPI = (function () {
+  if (typeof window !== 'undefined' && window.RevealMarkdown) {
+    return window.RevealMarkdown
+  }
+  // Fallback - shouldn't happen in normal usage
+  return {}
+})()
+
+export default RevealMarkdownAPI

--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -1,5 +1,7 @@
 /* eslint-env browser, jquery */
-/* global serverurl, Reveal, RevealMarkdown */
+/* global serverurl, Reveal */
+
+import RevealMarkdown from './reveal-markdown'
 
 import { preventXSS } from './render'
 import { md, updateLastChange, removeDOMEvents, finishView } from './extra'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -260,7 +260,6 @@ module.exports = {
       'script-loader!ot',
       'flowchart.js',
       'imports-loader?Raphael=raphael!js-sequence-diagrams',
-      'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/index.js')
     ],
     'index-styles': [
@@ -323,7 +322,6 @@ module.exports = {
       'script-loader!vega-lite',
       'script-loader!vega-embed',
       'expose-loader?io!socket.io-client',
-      'expose-loader?RevealMarkdown!reveal-markdown',
       'expose-loader?L!leaflet',
       path.join(__dirname, 'public/js/index.js')
     ],
@@ -332,7 +330,6 @@ module.exports = {
       'regenerator-runtime/runtime',
       'flowchart.js',
       'imports-loader?Raphael=raphael!js-sequence-diagrams',
-      'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/pretty.js')
     ],
     'pretty-styles': [
@@ -363,7 +360,6 @@ module.exports = {
       'script-loader!vega',
       'script-loader!vega-lite',
       'script-loader!vega-embed',
-      'expose-loader?RevealMarkdown!reveal-markdown',
       'expose-loader?L!leaflet',
       path.join(__dirname, 'public/js/pretty.js')
     ],
@@ -373,7 +369,6 @@ module.exports = {
       'bootstrap-tooltip',
       'flowchart.js',
       'imports-loader?Raphael=raphael!js-sequence-diagrams',
-      'expose-loader?RevealMarkdown!reveal-markdown',
       path.join(__dirname, 'public/js/slide.js')
     ],
     'slide-styles': [
@@ -408,7 +403,6 @@ module.exports = {
       'script-loader!vega-lite',
       'script-loader!vega-embed',
       'expose-loader?Reveal!reveal.js',
-      'expose-loader?RevealMarkdown!reveal-markdown',
       'expose-loader?L!leaflet',
       path.join(__dirname, 'public/js/slide.js')
     ]


### PR DESCRIPTION
- Removed the use of global `window.RevealMarkdown` in favor of direct ES module imports in `index.js`, `pretty.js`, and `slide.js`.
- Updated `reveal-markdown.js` to export as an ES module, ensuring compatibility with modern JavaScript practices.